### PR TITLE
Feature: Serialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /bin
 .*.sw?
 compile_commands.json
+*.bgtkml

--- a/include/gtk-ml.h
+++ b/include/gtk-ml.h
@@ -31,6 +31,9 @@
 #define GTKML_F_CARRY 0x1
 #define GTKML_F_NONE 0x0
 
+#define GTKML_STD_APPLICATION 0x0
+#define GTKML_STD_NEW_WINDOW 0x1
+
 #define GTKML_I_ARITH 0x1
 #define GTKML_I_IMM 0x2
 #define GTKML_I_IMM_EXTERN 0x4
@@ -70,18 +73,22 @@
 #define GTKML_II_PUSH_IMM 0x0
 #define GTKML_II_POP 0x1
 #define GTKML_II_GET_IMM 0x2
+#define GTKML_II_MAP_IMM 0x11
 
 #define GTKML_IBR_CALL_FFI 0x0
 #define GTKML_IBR_CALL 0x1
 #define GTKML_IBR_RET 0x2
+#define GTKML_IBR_CALL_STD 0x3
 
 #define GTKML_EII_PUSH_EXT_IMM 0x0
 #define GTKML_EII_POP_EXT 0x1
 #define GTKML_EII_GET_EXT_IMM 0x2
+#define GTKML_EII_MAP_EXT_IMM 0x11
 
 #define GTKML_EIBR_CALL_EXT_FFI 0x0
 #define GTKML_EIBR_CALL_EXT 0x1
 #define GTKML_EIBR_RET_EXT 0x2
+#define GTKML_EIBR_CALL_EXT_STD 0x3
 
 #define GTKML_SIA_NOP "NOP"
 #define GTKML_SIA_HALT "HALT"
@@ -113,7 +120,9 @@
 #define GTKML_SII_PUSH_IMM "PUSH_IMM"
 #define GTKML_SII_POP "POP"
 #define GTKML_SII_GET_IMM "GET_IMM"
+#define GTKML_SII_MAP_IMM "MAP_IMM"
 
+#define GTKML_SIBR_CALL_STD "CALL_STD"
 #define GTKML_SIBR_CALL_FFI "CALL_FFI"
 #define GTKML_SIBR_CALL "CALL"
 #define GTKML_SIBR_RET "RET"
@@ -122,7 +131,9 @@
 #define GTKML_SEII_PUSH_EXT_IMM "PUSH_EXT_IMM"
 #define GTKML_SEII_POP_EXT "POP_EXT"
 #define GTKML_SEII_GET_EXT_IMM "GET_EXT_IMM"
+#define GTKML_SEII_MAP_EXT_IMM "MAP_EXT_IMM"
 
+#define GTKML_SEIBR_CALL_EXT_STD "CALL_EXT_STD"
 #define GTKML_SEIBR_CALL_EXT_FFI "CALL_EXT_FFI"
 #define GTKML_SEIBR_CALL_EXT "CALL_EXT"
 #define GTKML_SEIBR_RET_EXT "RET_EXT"
@@ -150,19 +161,21 @@
 #define GTKML_ERR_OPCODE_ERROR ":error \"invalid opcode\""
 #define GTKML_ERR_PROGRAM_ERROR ":error \"not a program\""
 #define GTKML_ERR_LINKAGE_ERROR ":error \"symbol not found while linking\""
+#define GTKML_ERR_SER_ERROR ":error \"serialization error\""
+#define GTKML_ERR_DESER_ERROR ":error \"deserialization error\""
 #define GTKML_ERR_UNIMPLEMENTED ":error \"unimplemented\""
 
-#define gtk_ml_car(x) (x->value.s_list.car)
-#define gtk_ml_cdr(x) (x->value.s_list.cdr)
-#define gtk_ml_cddr(x) (x->value.s_list.cdr->value.s_list.cdr)
-#define gtk_ml_cdddr(x) (x->value.s_list.cdr->value.s_list.cdr->value.s_list.cdr)
-#define gtk_ml_cddddr(x) (x->value.s_list.cdr->value.s_list.cdr->value.s_list.cdr->value.s_list.cdr)
-#define gtk_ml_cdddddr(x) (x->value.s_list.cdr->value.s_list.cdr->value.s_list.cdr->value.s_list.cdr->value.s_list.cdr)
-#define gtk_ml_cdar(x) (x->value.s_list.cdr->value.s_list.car)
-#define gtk_ml_cddar(x) (x->value.s_list.cdr->value.s_list.cdr->value.s_list.car)
-#define gtk_ml_cdddar(x) (x->value.s_list.cdr->value.s_list.cdr->value.s_list.cdr->value.s_list.car)
-#define gtk_ml_cddddar(x) (x->value.s_list.cdr->value.s_list.cdr->value.s_list.cdr->value.s_list.cdr->value.s_list.car)
-#define gtk_ml_cdddddar(x) (x->value.s_list.cdr->value.s_list.cdr->value.s_list.cdr->value.s_list.cdr->value.s_list.cdr->value.s_list.car)
+#define gtk_ml_car(x) ((x)->value.s_list.car)
+#define gtk_ml_cdr(x) ((x)->value.s_list.cdr)
+#define gtk_ml_cddr(x) ((x)->value.s_list.cdr->value.s_list.cdr)
+#define gtk_ml_cdddr(x) ((x)->value.s_list.cdr->value.s_list.cdr->value.s_list.cdr)
+#define gtk_ml_cddddr(x) ((x)->value.s_list.cdr->value.s_list.cdr->value.s_list.cdr->value.s_list.cdr)
+#define gtk_ml_cdddddr(x) ((x)->value.s_list.cdr->value.s_list.cdr->value.s_list.cdr->value.s_list.cdr->value.s_list.cdr)
+#define gtk_ml_cdar(x) ((x)->value.s_list.cdr->value.s_list.car)
+#define gtk_ml_cddar(x) ((x)->value.s_list.cdr->value.s_list.cdr->value.s_list.car)
+#define gtk_ml_cdddar(x) ((x)->value.s_list.cdr->value.s_list.cdr->value.s_list.cdr->value.s_list.car)
+#define gtk_ml_cddddar(x) ((x)->value.s_list.cdr->value.s_list.cdr->value.s_list.cdr->value.s_list.cdr->value.s_list.car)
+#define gtk_ml_cdddddar(x) ((x)->value.s_list.cdr->value.s_list.cdr->value.s_list.cdr->value.s_list.cdr->value.s_list.cdr->value.s_list.car)
 
 typedef struct GtkMl_S GtkMl_S;
 typedef struct GtkMl_Context GtkMl_Context;
@@ -456,10 +469,18 @@ GTKML_PUBLIC gboolean gtk_ml_build_push_addr(GtkMl_Context *ctx, GtkMl_Builder *
 GTKML_PUBLIC gboolean gtk_ml_build_get_extended_imm(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, const char **err, GtkMl_Static imm64);
 // builds a push in the chosen basic_block
 GTKML_PUBLIC gboolean gtk_ml_build_get_imm(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, const char **err, GtkMl_Static imm64);
+// builds a push in the chosen basic_block
+GTKML_PUBLIC gboolean gtk_ml_build_map_extended_imm(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, const char **err, GtkMl_Static imm64);
+// builds a push in the chosen basic_block
+GTKML_PUBLIC gboolean gtk_ml_build_map_imm(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, const char **err, GtkMl_Static imm64);
 // builds a call to C in the chosen basic_block
 GTKML_PUBLIC gboolean gtk_ml_build_call_extended_ffi(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, const char **err, GtkMl_Static imm64);
 // builds a call to C in the chosen basic_block
 GTKML_PUBLIC gboolean gtk_ml_build_call_ffi(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, const char **err, GtkMl_Static imm64);
+// builds a call to C in the chosen basic_block
+GTKML_PUBLIC gboolean gtk_ml_build_call_extended_std(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, const char **err, GtkMl_Static imm64);
+// builds a call to C in the chosen basic_block
+GTKML_PUBLIC gboolean gtk_ml_build_call_std(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, const char **err, GtkMl_Static imm64);
 // builds a call instruction in the chosen basic_block
 GTKML_PUBLIC gboolean gtk_ml_build_call_extended(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, const char **err, GtkMl_Static program);
 // builds a call instruction in the chosen basic_block
@@ -528,6 +549,16 @@ GTKML_PUBLIC GtkMl_S *gtk_ml_nil(GtkMl_Context *ctx);
 
 GTKML_PUBLIC void gtk_ml_delete_reference(GtkMl_Context *ctx, void *);
 GTKML_PUBLIC void gtk_ml_delete_value(GtkMl_Context *ctx, void *);
+
+// serializes a value and returns a heap-allocated pointer to it
+GTKML_PUBLIC gboolean gtk_ml_serf_value(FILE *stream, const char **err, const GtkMl_S *value);
+// deserializes a value from a sequence of bytes
+GTKML_PUBLIC GtkMl_S *gtk_ml_deserf_value(GtkMl_Context *ctx, FILE *stream, const char **err);
+
+// serializes a program and returns a heap-allocated pointer to it
+GTKML_PUBLIC gboolean gtk_ml_serf_program(FILE *stream, const char **err, const GtkMl_Program *program);
+// deserializes a program from a sequence of bytes
+GTKML_PUBLIC gboolean gtk_ml_deserf_program(GtkMl_Context *ctx, GtkMl_Program *program, FILE *stream, const char **err);
 
 #endif /* ifndef GTK_ML_H */
 

--- a/test/hello.c
+++ b/test/hello.c
@@ -27,15 +27,15 @@ int main() {
         return 1;
     }
 
-    GtkMl_Program linked = gtk_ml_build(ctx, &err, builder);
-    if (!linked.exec) {
+    GtkMl_Program linked;
+    if (!gtk_ml_build(ctx, &linked, &err, builder)) {
         gtk_ml_del_context(ctx);
         free(src);
         fprintf(stderr, "%s\n", err);
         return 1;
     }
 
-    gtk_ml_load_program(ctx, linked);
+    gtk_ml_load_program(ctx, &linked);
 
     GtkMl_S *program = gtk_ml_get_export(ctx, &err, linked.start);
     if (!program) {
@@ -65,7 +65,7 @@ int main() {
 
     gtk_ml_del_context(ctx);
     free(src);
-    gtk_ml_del_program(linked);
+    gtk_ml_del_program(&linked);
 
     return status;
 }

--- a/test/hello.c
+++ b/test/hello.c
@@ -35,15 +35,43 @@ int main() {
         return 1;
     }
 
-    gtk_ml_load_program(ctx, &linked);
+    FILE *bgtkml = fopen("hello.bgtkml", "wb+");
+    if (!gtk_ml_serf_program(bgtkml, &err, &linked)) {
+        gtk_ml_del_context(ctx);
+        free(src);
+        fprintf(stderr, "%s\n", err);
+        return 1;
+    }
+    gtk_ml_del_program(&linked);
 
-    GtkMl_S *program = gtk_ml_get_export(ctx, &err, linked.start);
+    bgtkml = freopen("hello.bgtkml", "r", bgtkml);
+    GtkMl_Program loaded;
+    if (!gtk_ml_deserf_program(ctx, &loaded, bgtkml, &err)) {
+        gtk_ml_del_context(ctx);
+        free(src);
+        fprintf(stderr, "%s\n", err);
+        return 1;
+    }
+
+    fclose(bgtkml);
+
+    gtk_ml_load_program(ctx, &loaded);
+
+    if (!gtk_ml_dumpf_program(ctx, stdout, &err)) {
+        gtk_ml_del_context(ctx);
+        free(src);
+        fprintf(stderr, "%s\n", err);
+        return 1;
+    }
+
+    GtkMl_S *program = gtk_ml_get_export(ctx, &err, loaded.start);
     if (!program) {
         gtk_ml_del_context(ctx);
         free(src);
         fprintf(stderr, "%s\n", err);
         return 1;
     }
+    gtk_ml_del_program(&loaded);
 
     if (!gtk_ml_run_program(ctx, &err, program, NULL)) {
         gtk_ml_del_context(ctx);
@@ -65,7 +93,6 @@ int main() {
 
     gtk_ml_del_context(ctx);
     free(src);
-    gtk_ml_del_program(&linked);
 
     return status;
 }


### PR DESCRIPTION
This feature implements a custom binary format for serializing both code and data.

A program begins with the string "GTKML-P(" and ends with ")". It is then followed by length/string pair of the start function. Afterwards comes the length of the executable in word count and the executable itself. Since the bytecode is POD, it doesn't require any special processing. After the bytecode comes a length of the STATIC section in value count and then the statics themselves.

A value begins with "GTKML-V(" and ends with ")". The first 4 bytes represent the kind of the value. Afterwards come some value-specific bytes. For example, a list is encoded like (visual representation) "GTKML-V(<LIST>GTKML-V(<SYMBOL>0x3 app),GTKML-V(<INT>0x1234);)".

Additionally, some new opcodes and a "std library" have been added to make the serialization process possible. The values of kind USERDATA, LIGHTDATA and FFI cannot be reliably serialized and deserialized. Therefore FFI has been partially replaced by the CALL_STD bytecode, which accepts a single integer which is an offset to a table of standard functions. Currently those functions include "Application" and "new-window".