### PR TITLE
Implement define-intrinsic and the intrinsic pass

### DIFF
--- a/examples/hello.gtkml
+++ b/examples/hello.gtkml
@@ -1,8 +1,13 @@
+(define (number? expr) #t)
+
 ; define an intrinsical operator
 (define-intrinsic (intr-add a b)
-  (compile-expr CTX CODE-BUILDER BASIC-BLOCK b)
-  (compile-expr CTX CODE-BUILDER BASIC-BLOCK a)
-  (emit-bytecode CTX CODE-BUILDER BASIC-BLOCK cond-none :add))
+  (cond
+    (number? a) (do
+      (compile-expr CTX CODE-BUILDER BASIC-BLOCK b)
+      (compile-expr CTX CODE-BUILDER BASIC-BLOCK a)
+      (emit-bytecode CTX CODE-BUILDER BASIC-BLOCK cond-none :add))
+    :else (error {:err 'number-error :desc "not a number"})))
 
 ; define a Window macro
 (define-macro (Window title width height)

--- a/examples/hello.gtkml
+++ b/examples/hello.gtkml
@@ -1,14 +1,20 @@
+; define an intrinsical operator
+(define-intrinsic (intr-add a b)
+  (compile-expr CTX CODE-BUILDER BASIC-BLOCK b)
+  (compile-expr CTX CODE-BUILDER BASIC-BLOCK a)
+  (emit-bytecode CTX CODE-BUILDER BASIC-BLOCK cond-none :add))
+
 ; define a Window macro
 (define-macro (Window title width height)
   `(lambda (app)
     (new-window app ,title ,width ,height)))
-(define (add a b) (+ a b))
+
 ; run the application
 (Application "de.walterpi.example" flags-none {
   :activate (Window
     "gtk-ml example"
     (cond
-      #f         (error {:err 'cond-error :desc "cond evaluated in an incorrect way"})
-     (cmp 0 1 2) (error {:err 'cond-error :desc "cond evaluated in an incorrect way"})
-      :else      640)
-    (do 0 (add 240 240)))})
+      #f          (error {:err 'cond-error :desc "cond evaluated in an incorrect way"})
+      (cmp 0 1 2) (error {:err 'cond-error :desc "cond evaluated in an incorrect way"})
+      :else       640)
+    (do 0 (intr-add 240 240)))})

--- a/include/gtk-ml.h
+++ b/include/gtk-ml.h
@@ -36,6 +36,8 @@
 #define GTKML_STD_APPLICATION 0x0
 #define GTKML_STD_NEW_WINDOW 0x1
 #define GTKML_STD_ERROR 0x2
+#define GTKML_STD_COMPILE_EXPR 0x100
+#define GTKML_STD_EMIT_BYTECODE 0x101
 
 #define GTKML_I_ARITH 0x1
 #define GTKML_I_IMM 0x2
@@ -194,6 +196,7 @@ typedef enum GtkMl_Cmp {
 #define GTKML_ERR_ARGUMENT_ERROR "invalid arguments"
 #define GTKML_ERR_TYPE_ERROR "invalid type for expression"
 #define GTKML_ERR_CMP_ERROR "invalid comparison enum"
+#define GTKML_ERR_BYTECODE_ERROR "unrecognized bytecode keyword"
 #define GTKML_ERR_BOOLEAN_ERROR "expected a boolean expression"
 #define GTKML_ERR_ARITY_ERROR "invalid argument count"
 #define GTKML_ERR_BINDING_ERROR "binding not found"
@@ -228,6 +231,12 @@ typedef struct GtkMl_Builder GtkMl_Builder;
 typedef union GtkMl_Register GtkMl_Register;
 typedef uint64_t GtkMl_Static;
 typedef uint32_t GtkMl_Hash;
+
+typedef enum GtkMl_Stage {
+    GTKML_STAGE_INTR,
+    GTKML_STAGE_MACRO,
+    GTKML_STAGE_RUNTIME,
+} GtkMl_Stage;
 
 // a lexical analysis level token tag
 typedef enum GtkMl_TokenKind {
@@ -519,11 +528,12 @@ typedef struct GtkMl_BasicBlock {
     size_t cap_exec;
 } GtkMl_BasicBlock;
 
-typedef gboolean (*GtkMl_BuilderFn)(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+typedef gboolean (*GtkMl_BuilderFn)(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
 
 typedef struct GtkMl_BuilderMacro {
     const char *name;
     GtkMl_BuilderFn fn;
+    gboolean require_intrinsic;
     gboolean require_macro;
     gboolean require_runtime;
 } GtkMl_BuilderMacro;
@@ -539,6 +549,9 @@ struct GtkMl_Builder {
 
     unsigned int counter;
     unsigned int flags;
+
+    GtkMl_Context *intr_ctx;
+    GtkMl_Vm *intr_vm;
 
     GtkMl_Context *macro_ctx;
     GtkMl_Vm *macro_vm;
@@ -703,8 +716,8 @@ GTKML_PUBLIC GtkMl_S *gtk_ml_loadf(GtkMl_Context *ctx, char **src, GtkMl_S **err
 // loads an expression from a string
 GTKML_PUBLIC GtkMl_S *gtk_ml_loads(GtkMl_Context *ctx, GtkMl_S **err, const char *src);
 
-// do a macro pass on the selected lambda expression
-GTKML_PUBLIC gboolean gtk_ml_macro_pass(GtkMl_Builder *b, GtkMl_S **err, GtkMl_S *lambda);
+// compile a lambda expression to bytecode
+GTKML_PUBLIC gboolean gtk_ml_compile_intrinsics(GtkMl_Builder *b, GtkMl_S **err, GtkMl_S *intrinsic);
 // compile a lambda expression to bytecode
 GTKML_PUBLIC gboolean gtk_ml_compile_macros(GtkMl_Builder *b, GtkMl_S **err, GtkMl_S *macro);
 // compile a lambda expression to bytecode

--- a/include/gtk-ml.h
+++ b/include/gtk-ml.h
@@ -559,6 +559,9 @@ struct GtkMl_Builder {
     GtkMl_BuilderMacro *builders;
     size_t len_builder;
     size_t cap_builder;
+
+    GtkMl_HashSet intr_fns;
+    GtkMl_HashSet macro_fns;
 };
 
 union GtkMl_Register {

--- a/include/gtk-ml.h
+++ b/include/gtk-ml.h
@@ -717,9 +717,9 @@ GTKML_PUBLIC GtkMl_S *gtk_ml_loadf(GtkMl_Context *ctx, char **src, GtkMl_S **err
 GTKML_PUBLIC GtkMl_S *gtk_ml_loads(GtkMl_Context *ctx, GtkMl_S **err, const char *src);
 
 // compile a lambda expression to bytecode
-GTKML_PUBLIC gboolean gtk_ml_compile_intrinsics(GtkMl_Builder *b, GtkMl_S **err, GtkMl_S *intrinsic);
+GTKML_PUBLIC gboolean gtk_ml_compile_intrinsics(GtkMl_Builder *b, GtkMl_BasicBlock **start, GtkMl_S **err, GtkMl_S *intrinsic);
 // compile a lambda expression to bytecode
-GTKML_PUBLIC gboolean gtk_ml_compile_macros(GtkMl_Builder *b, GtkMl_S **err, GtkMl_S *macro);
+GTKML_PUBLIC gboolean gtk_ml_compile_macros(GtkMl_Builder *b, GtkMl_BasicBlock **start, GtkMl_S **err, GtkMl_S *macro);
 // compile a lambda expression to bytecode
 GTKML_PUBLIC gboolean gtk_ml_compile(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S **err, GtkMl_S *lambda);
 // compile a lambda expression to bytecode with expanding macros

--- a/src/gtk-ml.c
+++ b/src/gtk-ml.c
@@ -5377,7 +5377,7 @@ GTKML_PRIVATE GtkMl_S *vm_std_emit_bytecode(GtkMl_Context *ctx, GtkMl_S **err, G
             *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
             return 0;
         }
-        return gtk_ml_build_branch_extended_absolute(arg_ctx, arg_b, *arg_basic_block, err, gtk_ml_append_static(arg_b, imm))? new_true(ctx, NULL) : NULL;
+        return gtk_ml_build_branch_absolute_extended(arg_ctx, arg_b, *arg_basic_block, err, gtk_ml_append_static(arg_b, imm))? new_true(ctx, NULL) : NULL;
     } else if (strlen(bc_ret) == bc_len && strncmp(bc_ptr, bc_ret, bc_len) == 0) {
         return gtk_ml_build_ret(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
     } else if (strlen(bc_add) == bc_len && strncmp(bc_ptr, bc_add, bc_len) == 0) {

--- a/src/gtk-ml.c
+++ b/src/gtk-ml.c
@@ -5247,6 +5247,11 @@ GTKML_PRIVATE GtkMl_S *vm_std_compile_expr(GtkMl_Context *ctx, GtkMl_S **err, Gt
 GTKML_PRIVATE GtkMl_S *vm_std_emit_bytecode(GtkMl_Context *ctx, GtkMl_S **err, GtkMl_S *expr) {
     (void) expr;
 
+    GtkMl_S *imm = 0;
+    if (expr->value.s_int.value == 6) {
+        imm = gtk_ml_pop(ctx);
+    }
+
     GtkMl_S *bc = gtk_ml_pop(ctx);
     unsigned int arg_cond = gtk_ml_pop(ctx)->value.s_int.value;
     GtkMl_BasicBlock **arg_basic_block = gtk_ml_pop(ctx)->value.s_lightdata.userdata;
@@ -5255,11 +5260,148 @@ GTKML_PRIVATE GtkMl_S *vm_std_emit_bytecode(GtkMl_Context *ctx, GtkMl_S **err, G
     const char *bc_ptr = bc->value.s_keyword.ptr;
     size_t bc_len = bc->value.s_keyword.len;
 
+    const char *bc_halt = "halt";
+    const char *bc_push_imm = "push-imm";
+    const char *bc_push_addr = "push-addr";
+    const char *bc_pop = "pop";
+    const char *bc_setf_imm = "setf-imm";
+    const char *bc_popf = "popf";
+    const char *bc_define = "define";
+    const char *bc_bind = "bind";
+    const char *bc_bind_args = "bind-args";
+    const char *bc_get_imm = "get-imm";
+    const char *bc_list_imm = "list-imm";
+    const char *bc_map_imm = "map-imm";
+    const char *bc_set_imm = "set-imm";
+    const char *bc_array_imm = "array-imm";
+    const char *bc_setmm_imm = "setmm-imm";
+    const char *bc_getmm_imm = "getmm-imm";
+    const char *bc_var_imm = "var-imm";
+    const char *bc_getvar_imm = "getvar-imm";
+    const char *bc_assignvar_imm = "assignvar-imm";
+    const char *bc_call_std = "call-std";
+    const char *bc_call = "call";
+    const char *bc_branch_absolute = "branch-absolute";
+    const char *bc_ret = "ret";
     const char *bc_add = "add";
+    const char *bc_sub = "sub";
+    const char *bc_mul = "mul";
+    const char *bc_div = "div";
+    const char *bc_mod = "mod";
+    const char *bc_bitand = "bitand";
+    const char *bc_bitor = "bitor";
+    const char *bc_bitxor = "bitxor";
+    const char *bc_cmp = "cmp";
 
-    if (strlen(bc_add) == bc_len && strncmp(bc_ptr, bc_add, bc_len) == 0) {
-        gtk_ml_builder_set_cond(arg_b, arg_cond);
+    gtk_ml_builder_set_cond(arg_b, arg_cond);
+    if (strlen(bc_halt) == bc_len && strncmp(bc_ptr, bc_halt, bc_len) == 0) {
+        return gtk_ml_build_halt(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_push_imm) == bc_len && strncmp(bc_ptr, bc_push_imm, bc_len) == 0) {
+        if (!imm) {
+            *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
+            return 0;
+        }
+        return gtk_ml_build_push_extended_imm(arg_ctx, arg_b, *arg_basic_block, err, gtk_ml_append_static(arg_b, imm))? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_push_addr) == bc_len && strncmp(bc_ptr, bc_push_addr, bc_len) == 0) {
+        if (!imm) {
+            *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
+            return 0;
+        }
+        return gtk_ml_build_push_extended_addr(arg_ctx, arg_b, *arg_basic_block, err, gtk_ml_append_static(arg_b, imm))? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_pop) == bc_len && strncmp(bc_ptr, bc_pop, bc_len) == 0) {
+        return gtk_ml_build_pop(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_setf_imm) == bc_len && strncmp(bc_ptr, bc_setf_imm, bc_len) == 0) {
+        if (!imm) {
+            *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
+            return 0;
+        }
+        return gtk_ml_build_setf_extended_imm(arg_ctx, arg_b, *arg_basic_block, err, gtk_ml_append_static(arg_b, imm))? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_popf) == bc_len && strncmp(bc_ptr, bc_popf, bc_len) == 0) {
+        return gtk_ml_build_popf(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_define) == bc_len && strncmp(bc_ptr, bc_define, bc_len) == 0) {
+        return gtk_ml_build_define(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_bind) == bc_len && strncmp(bc_ptr, bc_bind, bc_len) == 0) {
+        return gtk_ml_build_bind(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_bind_args) == bc_len && strncmp(bc_ptr, bc_bind_args, bc_len) == 0) {
+        return gtk_ml_build_bind_args(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_get_imm) == bc_len && strncmp(bc_ptr, bc_get_imm, bc_len) == 0) {
+        if (!imm) {
+            *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
+            return 0;
+        }
+        return gtk_ml_build_get_extended_imm(arg_ctx, arg_b, *arg_basic_block, err, gtk_ml_append_static(arg_b, imm))? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_list_imm) == bc_len && strncmp(bc_ptr, bc_list_imm, bc_len) == 0) {
+        if (!imm) {
+            *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
+            return 0;
+        }
+        return gtk_ml_build_list_extended_imm(arg_ctx, arg_b, *arg_basic_block, err, gtk_ml_append_static(arg_b, imm))? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_map_imm) == bc_len && strncmp(bc_ptr, bc_map_imm, bc_len) == 0) {
+        if (!imm) {
+            *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
+            return 0;
+        }
+        return gtk_ml_build_map_extended_imm(arg_ctx, arg_b, *arg_basic_block, err, gtk_ml_append_static(arg_b, imm))? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_set_imm) == bc_len && strncmp(bc_ptr, bc_set_imm, bc_len) == 0) {
+        if (!imm) {
+            *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
+            return 0;
+        }
+        return gtk_ml_build_set_extended_imm(arg_ctx, arg_b, *arg_basic_block, err, gtk_ml_append_static(arg_b, imm))? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_array_imm) == bc_len && strncmp(bc_ptr, bc_array_imm, bc_len) == 0) {
+        if (!imm) {
+            *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
+            return 0;
+        }
+        return gtk_ml_build_array_extended_imm(arg_ctx, arg_b, *arg_basic_block, err, gtk_ml_append_static(arg_b, imm))? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_setmm_imm) == bc_len && strncmp(bc_ptr, bc_setmm_imm, bc_len) == 0) {
+        return gtk_ml_build_setmm_imm(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_getmm_imm) == bc_len && strncmp(bc_ptr, bc_getmm_imm, bc_len) == 0) {
+        return gtk_ml_build_getmm_imm(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_var_imm) == bc_len && strncmp(bc_ptr, bc_var_imm, bc_len) == 0) {
+        return gtk_ml_build_var_imm(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_getvar_imm) == bc_len && strncmp(bc_ptr, bc_getvar_imm, bc_len) == 0) {
+        return gtk_ml_build_getvar_imm(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_assignvar_imm) == bc_len && strncmp(bc_ptr, bc_assignvar_imm, bc_len) == 0) {
+        return gtk_ml_build_assignvar_imm(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_call_std) == bc_len && strncmp(bc_ptr, bc_call_std, bc_len) == 0) {
+        if (!imm) {
+            *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
+            return 0;
+        }
+        return gtk_ml_build_call_extended_std(arg_ctx, arg_b, *arg_basic_block, err, gtk_ml_append_static(arg_b, imm))? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_call) == bc_len && strncmp(bc_ptr, bc_call, bc_len) == 0) {
+        return gtk_ml_build_call(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_branch_absolute) == bc_len && strncmp(bc_ptr, bc_branch_absolute, bc_len) == 0) {
+        if (!imm) {
+            *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
+            return 0;
+        }
+        return gtk_ml_build_branch_extended_absolute(arg_ctx, arg_b, *arg_basic_block, err, gtk_ml_append_static(arg_b, imm))? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_ret) == bc_len && strncmp(bc_ptr, bc_ret, bc_len) == 0) {
+        return gtk_ml_build_ret(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_add) == bc_len && strncmp(bc_ptr, bc_add, bc_len) == 0) {
         return gtk_ml_build_add(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_sub) == bc_len && strncmp(bc_ptr, bc_sub, bc_len) == 0) {
+        return gtk_ml_build_sub(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_mul) == bc_len && strncmp(bc_ptr, bc_mul, bc_len) == 0) {
+        return gtk_ml_build_mul(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_div) == bc_len && strncmp(bc_ptr, bc_div, bc_len) == 0) {
+        return gtk_ml_build_div(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_mod) == bc_len && strncmp(bc_ptr, bc_mod, bc_len) == 0) {
+        return gtk_ml_build_mod(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_bitand) == bc_len && strncmp(bc_ptr, bc_bitand, bc_len) == 0) {
+        return gtk_ml_build_bitand(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_bitor) == bc_len && strncmp(bc_ptr, bc_bitor, bc_len) == 0) {
+        return gtk_ml_build_bitor(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_bitxor) == bc_len && strncmp(bc_ptr, bc_bitxor, bc_len) == 0) {
+        return gtk_ml_build_bitxor(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_cmp) == bc_len && strncmp(bc_ptr, bc_cmp, bc_len) == 0) {
+        if (!imm) {
+            *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
+            return 0;
+        }
+        return gtk_ml_build_cmp(arg_ctx, arg_b, *arg_basic_block, err, gtk_ml_append_static(arg_b, imm))? new_true(ctx, NULL) : NULL;
     } else {
         *err = gtk_ml_error(ctx, "bytecode-error", GTKML_ERR_BYTECODE_ERROR, bc->span.ptr != NULL, bc->span.line, bc->span.col, 0);
         return NULL;

--- a/src/gtk-ml.c
+++ b/src/gtk-ml.c
@@ -79,39 +79,44 @@ GTKML_PRIVATE void delete(GtkMl_Context *ctx, GtkMl_S *s);
 GTKML_PRIVATE void del(GtkMl_Context *ctx, GtkMl_S *s);
 GTKML_PRIVATE void gtk_ml_object_unref(GtkMl_Context *ctx, void *obj);
 
-GTKML_PRIVATE gboolean builder_do(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_lambda(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_macro(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_cond(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_while(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_add(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_sub(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_mul(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_div(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_mod(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_bitnot(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_bitand(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_bitor(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_bitxor(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_cmp(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_var(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_vararg(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_quote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_quasiquote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_unquote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_define(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_define_macro(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_application(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_new_window(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_setmetamap(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_getmetamap(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_getvar(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_assignvar(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_error(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_compile_expr(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_emit_bytecode(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_do(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_lambda(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_macro(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_cond(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_while(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_add(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_sub(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_mul(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_div(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_mod(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_bitnot(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_bitand(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_bitor(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_bitxor(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_cmp(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_var(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_vararg(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_quote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_quasiquote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_unquote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_define(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_define_macro(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_define_intrinsic(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_application(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_new_window(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_setmetamap(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_getmetamap(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_getvar(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_assignvar(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_error(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
 
 GTKML_PRIVATE GtkMl_S *vm_std_application(GtkMl_Context *ctx, GtkMl_S **err, GtkMl_S *expr);
 GTKML_PRIVATE GtkMl_S *vm_std_new_window(GtkMl_Context *ctx, GtkMl_S **err, GtkMl_S *expr);
 GTKML_PRIVATE GtkMl_S *vm_std_error(GtkMl_Context *ctx, GtkMl_S **err, GtkMl_S *expr);
+GTKML_PRIVATE GtkMl_S *vm_std_compile_expr(GtkMl_Context *ctx, GtkMl_S **err, GtkMl_S *expr);
+GTKML_PRIVATE GtkMl_S *vm_std_emit_bytecode(GtkMl_Context *ctx, GtkMl_S **err, GtkMl_S *expr);
 
 GTKML_PRIVATE gboolean gtk_ml_vm_run(GtkMl_Vm *vm, GtkMl_S **err);
 
@@ -404,6 +409,8 @@ GTKML_PRIVATE GtkMl_S *(*STD[])(GtkMl_Context *, GtkMl_S **, GtkMl_S *) = {
     [GTKML_STD_APPLICATION] = vm_std_application,
     [GTKML_STD_NEW_WINDOW] = vm_std_new_window,
     [GTKML_STD_ERROR] = vm_std_error,
+    [GTKML_STD_COMPILE_EXPR] = vm_std_compile_expr,
+    [GTKML_STD_EMIT_BYTECODE] = vm_std_emit_bytecode,
 };
 
 GTKML_PRIVATE GtkMl_Hasher DEFAULT_HASHER = {
@@ -433,6 +440,7 @@ GtkMl_Context *gtk_ml_new_context() {
     ctx->top_scope = &gtk_ml_car(ctx->bindings);
 
     gtk_ml_define(ctx, new_symbol(ctx, NULL, 0, "flags-none", 10), new_int(ctx, NULL, G_APPLICATION_FLAGS_NONE));
+    gtk_ml_define(ctx, new_symbol(ctx, NULL, 0, "cond-none", 9), new_int(ctx, NULL, GTKML_F_NONE));
 
     ctx->parser.readers = malloc(sizeof(GtkMl_Reader) * 64);
     ctx->parser.len_reader = 0;
@@ -585,6 +593,9 @@ GtkMl_Builder *gtk_ml_new_builder() {
     b->counter = 0;
     b->flags = 0;
 
+    b->intr_ctx = gtk_ml_new_context();
+    b->intr_vm = b->intr_ctx->vm;
+
     b->macro_ctx = gtk_ml_new_context();
     b->macro_vm = b->macro_ctx->vm;
 
@@ -592,10 +603,29 @@ GtkMl_Builder *gtk_ml_new_builder() {
     b->len_builder = 0;
     b->cap_builder = 64;
 
+    char *name_compile_expr = malloc(strlen("compile-expr") + 1);
+    strcpy(name_compile_expr, "compile-expr");
+    b->builders[b->len_builder].name = name_compile_expr;
+    b->builders[b->len_builder].fn = builder_compile_expr;
+    b->builders[b->len_builder].require_intrinsic = 1;
+    b->builders[b->len_builder].require_macro = 0;
+    b->builders[b->len_builder].require_runtime = 0;
+    ++b->len_builder;
+
+    char *name_emit_bytecode = malloc(strlen("emit-bytecode") + 1);
+    strcpy(name_emit_bytecode, "emit-bytecode");
+    b->builders[b->len_builder].name = name_emit_bytecode;
+    b->builders[b->len_builder].fn = builder_emit_bytecode;
+    b->builders[b->len_builder].require_intrinsic = 1;
+    b->builders[b->len_builder].require_macro = 0;
+    b->builders[b->len_builder].require_runtime = 0;
+    ++b->len_builder;
+
     char *name_do = malloc(strlen("do") + 1);
     strcpy(name_do, "do");
     b->builders[b->len_builder].name = name_do;
     b->builders[b->len_builder].fn = builder_do;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -604,6 +634,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_lambda, "lambda");
     b->builders[b->len_builder].name = name_lambda;
     b->builders[b->len_builder].fn = builder_lambda;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -612,6 +643,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_macro, "macro");
     b->builders[b->len_builder].name = name_macro;
     b->builders[b->len_builder].fn = builder_macro;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 1;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -620,6 +652,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_cond, "cond");
     b->builders[b->len_builder].name = name_cond;
     b->builders[b->len_builder].fn = builder_cond;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -628,6 +661,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_while, "while");
     b->builders[b->len_builder].name = name_while;
     b->builders[b->len_builder].fn = builder_while;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -636,6 +670,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_add, "+");
     b->builders[b->len_builder].name = name_add;
     b->builders[b->len_builder].fn = builder_add;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -644,6 +679,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_sub, "-");
     b->builders[b->len_builder].name = name_sub;
     b->builders[b->len_builder].fn = builder_sub;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -652,6 +688,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_mul, "*");
     b->builders[b->len_builder].name = name_mul;
     b->builders[b->len_builder].fn = builder_mul;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -660,6 +697,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_div, "/");
     b->builders[b->len_builder].name = name_div;
     b->builders[b->len_builder].fn = builder_div;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -668,6 +706,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_mod, "%");
     b->builders[b->len_builder].name = name_mod;
     b->builders[b->len_builder].fn = builder_mod;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -676,6 +715,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_bitnot, "bit-not");
     b->builders[b->len_builder].name = name_bitnot;
     b->builders[b->len_builder].fn = builder_bitnot;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -684,6 +724,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_bitand, "bit-and");
     b->builders[b->len_builder].name = name_bitand;
     b->builders[b->len_builder].fn = builder_bitand;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -692,6 +733,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_bitor, "bit-or");
     b->builders[b->len_builder].name = name_bitor;
     b->builders[b->len_builder].fn = builder_bitor;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -700,6 +742,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_bitxor, "bit-xor");
     b->builders[b->len_builder].name = name_bitxor;
     b->builders[b->len_builder].fn = builder_bitxor;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -708,6 +751,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_cmp, "cmp");
     b->builders[b->len_builder].name = name_cmp;
     b->builders[b->len_builder].fn = builder_cmp;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -716,6 +760,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_var, "var");
     b->builders[b->len_builder].name = name_var;
     b->builders[b->len_builder].fn = builder_var;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -724,6 +769,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_vararg, "vararg");
     b->builders[b->len_builder].name = name_vararg;
     b->builders[b->len_builder].fn = builder_vararg;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -732,6 +778,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_quote, "quote");
     b->builders[b->len_builder].name = name_quote;
     b->builders[b->len_builder].fn = builder_quote;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -740,6 +787,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_quasiquote, "quasiquote");
     b->builders[b->len_builder].name = name_quasiquote;
     b->builders[b->len_builder].fn = builder_quasiquote;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -748,6 +796,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_unquote, "unquote");
     b->builders[b->len_builder].name = name_unquote;
     b->builders[b->len_builder].fn = builder_unquote;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -756,6 +805,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_define, "define");
     b->builders[b->len_builder].name = name_define;
     b->builders[b->len_builder].fn = builder_define;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -764,6 +814,16 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_define_macro, "define-macro");
     b->builders[b->len_builder].name = name_define_macro;
     b->builders[b->len_builder].fn = builder_define_macro;
+    b->builders[b->len_builder].require_intrinsic = 0;
+    b->builders[b->len_builder].require_macro = 0;
+    b->builders[b->len_builder].require_runtime = 0;
+    ++b->len_builder;
+
+    char *name_define_intrinsic = malloc(strlen("define-intrinsic") + 1);
+    strcpy(name_define_intrinsic, "define-intrinsic");
+    b->builders[b->len_builder].name = name_define_intrinsic;
+    b->builders[b->len_builder].fn = builder_define_intrinsic;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -772,6 +832,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_application, "Application");
     b->builders[b->len_builder].name = name_application;
     b->builders[b->len_builder].fn = builder_application;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 1;
     ++b->len_builder;
@@ -780,6 +841,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_new_window, "new-window");
     b->builders[b->len_builder].name = name_new_window;
     b->builders[b->len_builder].fn = builder_new_window;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 1;
     ++b->len_builder;
@@ -788,6 +850,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_setmetamap, "setmetamap");
     b->builders[b->len_builder].name = name_setmetamap;
     b->builders[b->len_builder].fn = builder_setmetamap;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -796,6 +859,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_getmetamap, "getmetamap");
     b->builders[b->len_builder].name = name_getmetamap;
     b->builders[b->len_builder].fn = builder_getmetamap;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -804,6 +868,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_getvar, "get");
     b->builders[b->len_builder].name = name_getvar;
     b->builders[b->len_builder].fn = builder_getvar;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -812,6 +877,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_assignvar, "assign");
     b->builders[b->len_builder].name = name_assignvar;
     b->builders[b->len_builder].fn = builder_assignvar;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -820,6 +886,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_error, "error");
     b->builders[b->len_builder].name = name_error;
     b->builders[b->len_builder].fn = builder_error;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -827,7 +894,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     return b;
 }
 
-gboolean build(GtkMl_Context *ctx, GtkMl_Program *out, GtkMl_S **err, GtkMl_Builder *b, gboolean macro) {
+gboolean build(GtkMl_Context *ctx, GtkMl_Program *out, GtkMl_S **err, GtkMl_Builder *b, GtkMl_Stage stage) {
     size_t n = 0;
     size_t n_static = b->len_static;
     for (size_t i = 0; i < b->len_bb; i++) {
@@ -935,7 +1002,8 @@ gboolean build(GtkMl_Context *ctx, GtkMl_Program *out, GtkMl_S **err, GtkMl_Buil
         }
     }
 
-    if (macro) {
+    switch (stage) {
+    case GTKML_STAGE_INTR:
         for (size_t i = 0; i < b->len_bb; i++) {
             free(b->basic_blocks[i].exec);
         }
@@ -947,7 +1015,31 @@ gboolean build(GtkMl_Context *ctx, GtkMl_Program *out, GtkMl_S **err, GtkMl_Buil
         out->n_exec = n;
         out->statics = statics;
         out->n_static = n_static;
-    } else {
+        break;
+    case GTKML_STAGE_MACRO: {
+        // first we transfer the values from the intr context into the macro context
+        GtkMl_S *intr_values = b->intr_ctx->first;
+        b->intr_ctx->first = NULL;
+        GtkMl_S **prev = &b->macro_ctx->first;
+        while (*prev) {
+            prev = &(*prev)->next;
+        }
+        *prev = intr_values;
+        // then it's safe to delete the intr context and vm
+
+        for (size_t i = 0; i < b->len_bb; i++) {
+            free(b->basic_blocks[i].exec);
+        }
+        b->len_bb = 0;
+        b->len_static = 1;
+
+        out->start = NULL;
+        out->exec = result;
+        out->n_exec = n;
+        out->statics = statics;
+        out->n_static = n_static;
+    } break;
+    case GTKML_STAGE_RUNTIME: {
         // first we transfer the values from the macro context into the real context
         GtkMl_S *macro_values = b->macro_ctx->first;
         b->macro_ctx->first = NULL;
@@ -958,6 +1050,8 @@ gboolean build(GtkMl_Context *ctx, GtkMl_Program *out, GtkMl_S **err, GtkMl_Buil
         *prev = macro_values;
         // then it's safe to delete the macro context and vm
         gtk_ml_del_context(b->macro_ctx);
+        // and the intr context
+        gtk_ml_del_context(b->intr_ctx);
 
         for (size_t i = 0; i < b->len_bb; i++) {
             free(b->basic_blocks[i].exec);
@@ -977,17 +1071,22 @@ gboolean build(GtkMl_Context *ctx, GtkMl_Program *out, GtkMl_S **err, GtkMl_Buil
         out->n_exec = n;
         out->statics = statics;
         out->n_static = n_static;
+    } break;
     }
 
     return 1;
 }
 
+gboolean gtk_ml_build_intrinsics(GtkMl_Program *out, GtkMl_S **err, GtkMl_Builder *b) {
+    return build(NULL, out, err, b, GTKML_STAGE_INTR);
+}
+
 gboolean gtk_ml_build_macros(GtkMl_Program *out, GtkMl_S **err, GtkMl_Builder *b) {
-    return build(NULL, out, err, b, 1);
+    return build(NULL, out, err, b, GTKML_STAGE_MACRO);
 }
 
 gboolean gtk_ml_build(GtkMl_Context *ctx, GtkMl_Program *out, GtkMl_S **err, GtkMl_Builder *b) {
-    return build(ctx, out, err, b, 0);
+    return build(ctx, out, err, b, GTKML_STAGE_RUNTIME);
 }
 
 GTKML_PUBLIC void gtk_ml_del_program(GtkMl_Program* program) {
@@ -2008,16 +2107,17 @@ GtkMl_S *gtk_ml_loads(GtkMl_Context *ctx, GtkMl_S **err, const char *src) {
 }
 
 GTKML_PRIVATE gboolean compile_std_call(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, uint64_t function, GtkMl_S *args, gboolean compile_first);
-GTKML_PRIVATE gboolean compile_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt);
-GTKML_PRIVATE gboolean compile_program(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, const char *linkage_name, GtkMl_S *stmt, gboolean ret);
+GTKML_PRIVATE gboolean compile_runtime_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt);
+GTKML_PRIVATE gboolean compile_runtime_program(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, const char *linkage_name, GtkMl_S *stmt, gboolean ret);
 
-GTKML_PRIVATE gboolean compile_cond_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean compile_macro_quasi_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S *stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean compile_macro_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean compile_macro_body(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S *stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean compile_macro_program(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, const char *linkage_name, GtkMl_S *stmt, gboolean ret, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean compile_cond_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean compile_quasi_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S *stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean compile_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean compile_body(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S *stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean compile_program(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, const char *linkage_name, GtkMl_S *stmt, gboolean ret, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
 
-gboolean builder_application(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_application(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+    (void) allow_intr;
     (void) allow_macro;
     (void) allow_runtime;
     (void) allow_macro_expansion;
@@ -2033,7 +2133,8 @@ gboolean builder_application(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBl
     return compile_std_call(ctx, b, basic_block, err, GTKML_STD_APPLICATION, *stmt, 0);
 }
 
-gboolean builder_new_window(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_new_window(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+    (void) allow_intr;
     (void) allow_macro;
     (void) allow_runtime;
     (void) allow_macro_expansion;
@@ -2049,7 +2150,7 @@ gboolean builder_new_window(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlo
     return compile_std_call(ctx, b, basic_block, err, GTKML_STD_NEW_WINDOW, *stmt, 0);
 }
 
-gboolean builder_setmetamap(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_setmetamap(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL || gtk_ml_cdr(args)->kind == GTKML_S_NIL) {
@@ -2060,16 +2161,16 @@ gboolean builder_setmetamap(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlo
     GtkMl_S *map = gtk_ml_car(args);
     GtkMl_S *metamap = gtk_ml_cdar(args);
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, &map, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, &map, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
-    if (!compile_macro_expression(ctx, b, basic_block, err, &metamap, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, &metamap, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_setmm_imm(ctx, b, *basic_block, err);
 }
 
-gboolean builder_getmetamap(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_getmetamap(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL) {
@@ -2079,13 +2180,13 @@ gboolean builder_getmetamap(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlo
 
     GtkMl_S *map = gtk_ml_car(args);
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, &map, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, &map, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_getmm_imm(ctx, b, *basic_block, err);
 }
 
-gboolean builder_getvar(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_getvar(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL) {
@@ -2095,13 +2196,13 @@ gboolean builder_getvar(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *
 
     GtkMl_S *map = gtk_ml_car(args);
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, &map, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, &map, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_getvar_imm(ctx, b, *basic_block, err);
 }
 
-gboolean builder_assignvar(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_assignvar(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL || gtk_ml_cdr(args)->kind == GTKML_S_NIL) {
@@ -2112,16 +2213,17 @@ gboolean builder_assignvar(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBloc
     GtkMl_S *var = gtk_ml_car(args);
     GtkMl_S *newvalue = gtk_ml_cdar(args);
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, &var, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, &var, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
-    if (!compile_macro_expression(ctx, b, basic_block, err, &newvalue, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, &newvalue, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_assignvar_imm(ctx, b, *basic_block, err);
 }
 
-gboolean builder_error(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_error(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+    (void) allow_intr;
     (void) allow_macro;
     (void) allow_runtime;
     (void) allow_macro_expansion;
@@ -2135,7 +2237,7 @@ gboolean builder_error(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **
     return compile_std_call(ctx, b, basic_block, err, GTKML_STD_ERROR, *stmt, 0);
 }
 
-gboolean builder_define(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_define(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL
@@ -2148,7 +2250,7 @@ gboolean builder_define(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *
     if (definition->kind == GTKML_S_SYMBOL) {
         GtkMl_S *name = definition;
         GtkMl_S **value = &gtk_ml_cdar(args);
-        if (!compile_macro_expression(ctx, b, basic_block, err, value, allow_macro, allow_runtime, allow_macro_expansion)) {
+        if (!compile_expression(ctx, b, basic_block, err, value, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
             return 0;
         }
         if (!gtk_ml_build_push_extended_imm(ctx, b, *basic_block, err, gtk_ml_append_static(b, name))) {
@@ -2173,7 +2275,7 @@ gboolean builder_define(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *
         memcpy(linkage_name, name->value.s_symbol.ptr, len);
         linkage_name[len] = 0;
         GtkMl_BasicBlock *bb = gtk_ml_append_basic_block(b, linkage_name);
-        if (!compile_program(ctx, b, &bb, err, linkage_name, lambda, 1)) {
+        if (!compile_runtime_program(ctx, b, &bb, err, linkage_name, lambda, 1)) {
             return 0;
         }
         if (!gtk_ml_build_push_extended_addr(ctx, b, *basic_block, err, gtk_ml_append_static(b, new_string(ctx, NULL, linkage_name, strlen(linkage_name))))) {
@@ -2190,28 +2292,83 @@ gboolean builder_define(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *
 }
 
 
-gboolean builder_define_macro(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_define_macro(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     (void) ctx;
     (void) b;
     (void) basic_block;
     (void) err;
     (void) stmt;
+    (void) allow_intr;
     (void) allow_macro;
     (void) allow_runtime;
     (void) allow_macro_expansion;
     return 1;
 }
 
-gboolean builder_do(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_define_intrinsic(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+    (void) ctx;
+    (void) b;
+    (void) basic_block;
+    (void) err;
+    (void) stmt;
+    (void) allow_intr;
+    (void) allow_macro;
+    (void) allow_runtime;
+    (void) allow_macro_expansion;
+    return 1;
+}
+
+gboolean builder_compile_expr(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+    (void) b;
+    (void) basic_block;
+    (void) allow_intr;
+    (void) allow_macro;
+    (void) allow_runtime;
+    (void) allow_macro_expansion;
+    GtkMl_S *args = gtk_ml_cdr(*stmt);
+
+    if (args->kind == GTKML_S_NIL
+            || gtk_ml_cdr(args)->kind == GTKML_S_NIL
+            || gtk_ml_cddr(args)->kind == GTKML_S_NIL
+            || gtk_ml_cdddr(args)->kind == GTKML_S_NIL) {
+        *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, (*stmt)->span.ptr != NULL, (*stmt)->span.line, (*stmt)->span.col, 0);
+        return 0;
+    }
+
+    return compile_std_call(ctx, b, basic_block, err, GTKML_STD_COMPILE_EXPR, *stmt, 0);
+}
+
+gboolean builder_emit_bytecode(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+    (void) b;
+    (void) basic_block;
+    (void) allow_intr;
+    (void) allow_macro;
+    (void) allow_runtime;
+    (void) allow_macro_expansion;
+    GtkMl_S *args = gtk_ml_cdr(*stmt);
+
+    if (args->kind == GTKML_S_NIL
+            || gtk_ml_cdr(args)->kind == GTKML_S_NIL
+            || gtk_ml_cddr(args)->kind == GTKML_S_NIL
+            || gtk_ml_cdddr(args)->kind == GTKML_S_NIL
+            || gtk_ml_cddddr(args)->kind == GTKML_S_NIL) {
+        *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, (*stmt)->span.ptr != NULL, (*stmt)->span.line, (*stmt)->span.col, 0);
+        return 0;
+    }
+
+    return compile_std_call(ctx, b, basic_block, err, GTKML_STD_EMIT_BYTECODE, *stmt, 0);
+}
+
+gboolean builder_do(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL) {
         GtkMl_S *nil = new_nil(ctx, &(*stmt)->span);
-        return compile_macro_expression(ctx, b, basic_block, err, &nil, allow_macro, allow_runtime, allow_macro_expansion);
+        return compile_expression(ctx, b, basic_block, err, &nil, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
     }
 
     while (args->kind != GTKML_S_NIL) {
-        if (!compile_macro_expression(ctx, b, basic_block, err, &gtk_ml_car(args), allow_macro, allow_runtime, allow_macro_expansion)) {
+        if (!compile_expression(ctx, b, basic_block, err, &gtk_ml_car(args), allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
             return 0;
         }
         args = gtk_ml_cdr(args);
@@ -2225,7 +2382,7 @@ gboolean builder_do(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **bas
     return 1;
 }
 
-gboolean builder_lambda(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_lambda(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL
@@ -2242,10 +2399,10 @@ gboolean builder_lambda(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *
         return 0;
     }
 
-    return compile_macro_expression(ctx, b, basic_block, err, &lambda, allow_macro, allow_runtime, allow_macro_expansion);
+    return compile_expression(ctx, b, basic_block, err, &lambda, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
 }
 
-gboolean builder_macro(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_macro(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL
@@ -2262,10 +2419,10 @@ gboolean builder_macro(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **
         return 0;
     }
 
-    return compile_macro_expression(ctx, b, basic_block, err, &macro, allow_macro, allow_runtime, allow_macro_expansion);
+    return compile_expression(ctx, b, basic_block, err, &macro, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
 }
 
-gboolean builder_cond(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_cond(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
     GtkMl_S *_args = args;
 
@@ -2384,7 +2541,7 @@ gboolean builder_cond(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **b
             break;
         }
 
-        if (!compile_cond_expression(ctx, b, basic_block, err, cond, allow_macro, allow_runtime, allow_macro_expansion)) {
+        if (!compile_cond_expression(ctx, b, basic_block, err, cond, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
             return 0;
         }
         gtk_ml_builder_set_cond(b, GTKML_F_ZERO);
@@ -2408,7 +2565,7 @@ gboolean builder_cond(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **b
         GtkMl_S *cond = gtk_ml_car(args);
         GtkMl_S **body = &gtk_ml_cdar(args);
 
-        if (!compile_macro_expression(ctx, b, &branches[i], err, body, allow_macro, allow_runtime, allow_macro_expansion)) {
+        if (!compile_expression(ctx, b, &branches[i], err, body, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
             return 0;
         }
 
@@ -2434,7 +2591,7 @@ gboolean builder_cond(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **b
     return 1;
 }
 
-gboolean builder_while(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_while(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL) {
@@ -2527,7 +2684,7 @@ gboolean builder_while(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **
     char *end_name = malloc(strlen("while$$end") + 16);
     snprintf(end_name, strlen("while$$end") + 16, "while$%u$end", while_number);
 
-    compile_cond_expression(ctx, b, &cond, err, &gtk_ml_car(args), allow_macro, allow_runtime, allow_macro_expansion);
+    compile_cond_expression(ctx, b, &cond, err, &gtk_ml_car(args), allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
     // if true: jump to body
     gtk_ml_builder_set_cond(b, GTKML_F_ZERO);
     gtk_ml_build_branch_absolute_extended(ctx, b, cond, err, gtk_ml_append_static(b, new_string(ctx, NULL, body_name, strlen(body_name))));
@@ -2539,7 +2696,7 @@ gboolean builder_while(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **
         char *cond_name = malloc(strlen("while$$cond") + 16);
         snprintf(cond_name, strlen("while$$cond") + 16, "while$%u$cond", while_number);
 
-        compile_macro_expression(ctx, b, &body, err, &gtk_ml_car(args), allow_macro, allow_runtime, allow_macro_expansion);
+        compile_expression(ctx, b, &body, err, &gtk_ml_car(args), allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
         gtk_ml_build_branch_absolute_extended(ctx, b, body, err, gtk_ml_append_static(b, new_string(ctx, NULL, cond_name, strlen(cond_name))));
         args = gtk_ml_cdr(args);
     }
@@ -2549,7 +2706,7 @@ gboolean builder_while(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **
     return 1;
 }
 
-gboolean builder_add(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_add(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL && gtk_ml_cdr(args)->kind == GTKML_S_NIL) {
@@ -2560,26 +2717,26 @@ gboolean builder_add(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **ba
     GtkMl_S **lhs = &gtk_ml_car(args);
     GtkMl_S **rhs = &gtk_ml_cdar(args);
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, rhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, rhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
-    if (!compile_macro_expression(ctx, b, basic_block, err, lhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, lhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_add(ctx, b, *basic_block, err);
 }
 
-gboolean builder_sub(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_sub(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind != GTKML_S_NIL && gtk_ml_cdr(args)->kind == GTKML_S_NIL) {
         GtkMl_S **value = &gtk_ml_car(args);
         GtkMl_S *zero = new_int(ctx, &(*stmt)->span, 0);
 
-        if (!compile_macro_expression(ctx, b, basic_block, err, value, allow_macro, allow_runtime, allow_macro_expansion)) {
+        if (!compile_expression(ctx, b, basic_block, err, value, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
             return 0;
         }
-        if (!compile_macro_expression(ctx, b, basic_block, err, &zero, allow_macro, allow_runtime, allow_macro_expansion)) {
+        if (!compile_expression(ctx, b, basic_block, err, &zero, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
             return 0;
         }
         return gtk_ml_build_sub(ctx, b, *basic_block, err);
@@ -2593,16 +2750,16 @@ gboolean builder_sub(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **ba
     GtkMl_S **lhs = &gtk_ml_car(args);
     GtkMl_S **rhs = &gtk_ml_cdar(args);
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, rhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, rhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
-    if (!compile_macro_expression(ctx, b, basic_block, err, lhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, lhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_sub(ctx, b, *basic_block, err);
 }
 
-gboolean builder_mul(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_mul(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL && gtk_ml_cdr(args)->kind == GTKML_S_NIL) {
@@ -2613,16 +2770,16 @@ gboolean builder_mul(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **ba
     GtkMl_S **lhs = &gtk_ml_car(args);
     GtkMl_S **rhs = &gtk_ml_cdar(args);
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, rhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, rhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
-    if (!compile_macro_expression(ctx, b, basic_block, err, lhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, lhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_mul(ctx, b, *basic_block, err);
 }
 
-gboolean builder_div(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_div(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL && gtk_ml_cdr(args)->kind == GTKML_S_NIL) {
@@ -2633,16 +2790,16 @@ gboolean builder_div(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **ba
     GtkMl_S **lhs = &gtk_ml_car(args);
     GtkMl_S **rhs = &gtk_ml_cdar(args);
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, rhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, rhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
-    if (!compile_macro_expression(ctx, b, basic_block, err, lhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, lhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_div(ctx, b, *basic_block, err);
 }
 
-gboolean builder_mod(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_mod(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL && gtk_ml_cdr(args)->kind == GTKML_S_NIL) {
@@ -2653,16 +2810,16 @@ gboolean builder_mod(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **ba
     GtkMl_S **lhs = &gtk_ml_car(args);
     GtkMl_S **rhs = &gtk_ml_cdar(args);
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, rhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, rhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
-    if (!compile_macro_expression(ctx, b, basic_block, err, lhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, lhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_mod(ctx, b, *basic_block, err);
 }
 
-gboolean builder_bitnot(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_bitnot(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL) {
@@ -2673,16 +2830,16 @@ gboolean builder_bitnot(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *
     GtkMl_S **value = &gtk_ml_car(args);
     GtkMl_S *ff = new_int(ctx, &(*stmt)->span, 0xfffffffffffffffful);
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, &ff, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, &ff, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
-    if (!compile_macro_expression(ctx, b, basic_block, err, value, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, value, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_bitxor(ctx, b, *basic_block, err);
 }
 
-gboolean builder_bitand(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_bitand(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL && gtk_ml_cdr(args)->kind == GTKML_S_NIL) {
@@ -2693,16 +2850,16 @@ gboolean builder_bitand(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *
     GtkMl_S **lhs = &gtk_ml_car(args);
     GtkMl_S **rhs = &gtk_ml_cdar(args);
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, rhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, rhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
-    if (!compile_macro_expression(ctx, b, basic_block, err, lhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, lhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_bitand(ctx, b, *basic_block, err);
 }
 
-gboolean builder_bitor(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_bitor(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL && gtk_ml_cdr(args)->kind == GTKML_S_NIL) {
@@ -2713,16 +2870,16 @@ gboolean builder_bitor(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **
     GtkMl_S **lhs = &gtk_ml_car(args);
     GtkMl_S **rhs = &gtk_ml_cdar(args);
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, rhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, rhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
-    if (!compile_macro_expression(ctx, b, basic_block, err, lhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, lhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_bitor(ctx, b, *basic_block, err);
 }
 
-gboolean builder_bitxor(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_bitxor(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL && gtk_ml_cdr(args)->kind == GTKML_S_NIL) {
@@ -2733,21 +2890,21 @@ gboolean builder_bitxor(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *
     GtkMl_S **lhs = &gtk_ml_car(args);
     GtkMl_S **rhs = &gtk_ml_cdar(args);
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, rhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, rhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
-    if (!compile_macro_expression(ctx, b, basic_block, err, lhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, lhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_bitxor(ctx, b, *basic_block, err);
 }
 
-gboolean builder_cmp(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_cmp(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL
-            && gtk_ml_cdr(args)->kind == GTKML_S_NIL
-            && gtk_ml_cddr(args)->kind == GTKML_S_NIL) {
+            || gtk_ml_cdr(args)->kind == GTKML_S_NIL
+            || gtk_ml_cddr(args)->kind == GTKML_S_NIL) {
         *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, (*stmt)->span.ptr != NULL, (*stmt)->span.line, (*stmt)->span.col, 0);
         return 0;
     }
@@ -2773,16 +2930,16 @@ gboolean builder_cmp(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **ba
         return 0;
     }
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, rhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, rhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
-    if (!compile_macro_expression(ctx, b, basic_block, err, lhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, lhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_cmp(ctx, b, *basic_block, err, gtk_ml_append_static(b, cmp));
 }
 
-gboolean builder_var(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_var(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL) {
@@ -2795,10 +2952,10 @@ gboolean builder_var(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **ba
         return 0;
     }
 
-    return compile_macro_expression(ctx, b, basic_block, err, &var, allow_macro, allow_runtime, allow_macro_expansion);
+    return compile_expression(ctx, b, basic_block, err, &var, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
 }
 
-gboolean builder_vararg(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_vararg(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL) {
@@ -2811,10 +2968,10 @@ gboolean builder_vararg(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *
         return 0;
     }
 
-    return compile_macro_expression(ctx, b, basic_block, err, &vararg, allow_macro, allow_runtime, allow_macro_expansion);
+    return compile_expression(ctx, b, basic_block, err, &vararg, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
 }
 
-gboolean builder_quote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_quote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL) {
@@ -2827,10 +2984,10 @@ gboolean builder_quote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **
         return 0;
     }
 
-    return compile_macro_expression(ctx, b, basic_block, err, &quote, allow_macro, allow_runtime, allow_macro_expansion);
+    return compile_expression(ctx, b, basic_block, err, &quote, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
 }
 
-gboolean builder_quasiquote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_quasiquote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL) {
@@ -2843,10 +3000,10 @@ gboolean builder_quasiquote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlo
         return 0;
     }
 
-    return compile_macro_expression(ctx, b, basic_block, err, &quasiquote, allow_macro, allow_runtime, allow_macro_expansion);
+    return compile_expression(ctx, b, basic_block, err, &quasiquote, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
 }
 
-gboolean builder_unquote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_unquote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL) {
@@ -2859,10 +3016,10 @@ gboolean builder_unquote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock 
         return 0;
     }
 
-    return compile_macro_expression(ctx, b, basic_block, err, &unquote, allow_macro, allow_runtime, allow_macro_expansion);
+    return compile_expression(ctx, b, basic_block, err, &unquote, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
 }
 
-gboolean compile_cond_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean compile_cond_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     switch ((*stmt)->kind) {
     case GTKML_S_FALSE:
     case GTKML_S_TRUE:
@@ -2886,7 +3043,7 @@ gboolean compile_cond_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_Bas
         return gtk_ml_build_setf_extended_imm(ctx, b, *basic_block, err, gtk_ml_append_static(b, new_true(ctx, &(*stmt)->span)));
     case GTKML_S_LIST:
     case GTKML_S_SYMBOL:
-        if (!compile_macro_expression(ctx, b, basic_block, err, stmt, allow_macro, allow_runtime, allow_macro_expansion)) {
+        if (!compile_expression(ctx, b, basic_block, err, stmt, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
             return 0;
         }
         return gtk_ml_build_popf(ctx, b, *basic_block, err);
@@ -2897,13 +3054,13 @@ gboolean compile_cond_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_Bas
         if ((*stmt)->value.s_quote.expr->kind == GTKML_S_SYMBOL || (*stmt)->value.s_quote.expr->kind == GTKML_S_LIST) {
             return gtk_ml_build_setf_extended_imm(ctx, b, *basic_block, err, gtk_ml_append_static(b, new_true(ctx, &(*stmt)->span)));
         } else {
-            return compile_cond_expression(ctx, b, basic_block, err, &(*stmt)->value.s_quote.expr, allow_macro, allow_runtime, allow_macro_expansion);
+            return compile_cond_expression(ctx, b, basic_block, err, &(*stmt)->value.s_quote.expr, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
         }
     case GTKML_S_QUASIQUOTE:
         if ((*stmt)->value.s_quote.expr->kind == GTKML_S_SYMBOL || (*stmt)->value.s_quote.expr->kind == GTKML_S_LIST) {
             return gtk_ml_build_setf_extended_imm(ctx, b, *basic_block, err, gtk_ml_append_static(b, new_true(ctx, &(*stmt)->span)));
         } else {
-            return compile_cond_expression(ctx, b, basic_block, err, &(*stmt)->value.s_quote.expr, allow_macro, allow_runtime, allow_macro_expansion);
+            return compile_cond_expression(ctx, b, basic_block, err, &(*stmt)->value.s_quote.expr, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
         }
     case GTKML_S_UNQUOTE:
         *err = gtk_ml_error(ctx, "unquote-error", GTKML_ERR_UNQUOTE_ERROR, (*stmt)->span.ptr != NULL, (*stmt)->span.line, (*stmt)->span.col, 0);
@@ -2921,7 +3078,7 @@ gboolean compile_std_call(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock
         ++n;
     }
     while (args->kind != GTKML_S_NIL) {
-        if (!compile_expression(ctx, b, basic_block, err, &gtk_ml_car(args))) {
+        if (!compile_runtime_expression(ctx, b, basic_block, err, &gtk_ml_car(args))) {
             return 0;
         }
         args = gtk_ml_cdr(args);
@@ -2944,6 +3101,7 @@ struct CompileData {
     GtkMl_BasicBlock **basic_block;
     GtkMl_S **err;
     GtkMl_S *stmt;
+    gboolean allow_intr;
     gboolean allow_macro;
     gboolean allow_runtime;
     gboolean allow_macro_expansion;
@@ -2954,11 +3112,11 @@ GTKML_PRIVATE GtkMl_VisitResult compile_quasi_map(GtkMl_HashTrie *ht, void *key,
     (void) ht;
 
     struct CompileData *data = _data;
-    if (!compile_macro_quasi_expression(data->ctx, data->b, data->basic_block, data->err, key, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
+    if (!compile_quasi_expression(data->ctx, data->b, data->basic_block, data->err, key, data->allow_intr, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
         data->result = 0;
         return GTKML_VISIT_BREAK;
     }
-    if (!compile_macro_quasi_expression(data->ctx, data->b, data->basic_block, data->err, value, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
+    if (!compile_quasi_expression(data->ctx, data->b, data->basic_block, data->err, value, data->allow_intr, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
         data->result = 0;
         return GTKML_VISIT_BREAK;
     }
@@ -2969,7 +3127,7 @@ GTKML_PRIVATE GtkMl_VisitResult compile_quasi_set(GtkMl_HashSet *hs, void *key, 
     (void) hs;
 
     struct CompileData *data = _data;
-    if (!compile_macro_quasi_expression(data->ctx, data->b, data->basic_block, data->err, key, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
+    if (!compile_quasi_expression(data->ctx, data->b, data->basic_block, data->err, key, data->allow_intr, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
         data->result = 0;
         return GTKML_VISIT_BREAK;
     }
@@ -2981,7 +3139,7 @@ GTKML_PRIVATE GtkMl_VisitResult compile_quasi_array(GtkMl_Array *array, size_t i
     (void) idx;
 
     struct CompileData *data = _data;
-    if (!compile_macro_quasi_expression(data->ctx, data->b, data->basic_block, data->err, value, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
+    if (!compile_quasi_expression(data->ctx, data->b, data->basic_block, data->err, value, data->allow_intr, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
         data->result = 0;
         return GTKML_VISIT_BREAK;
     }
@@ -2994,11 +3152,11 @@ GTKML_PRIVATE GtkMl_VisitResult compile_map(GtkMl_HashTrie *ht, void *key_ptr, v
     GtkMl_S *value = value_ptr;
 
     struct CompileData *data = _data;
-    if (!compile_macro_expression(data->ctx, data->b, data->basic_block, data->err, &key, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
+    if (!compile_expression(data->ctx, data->b, data->basic_block, data->err, &key, data->allow_intr, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
         data->result = 0;
         return GTKML_VISIT_BREAK;
     }
-    if (!compile_macro_expression(data->ctx, data->b, data->basic_block, data->err, &value, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
+    if (!compile_expression(data->ctx, data->b, data->basic_block, data->err, &value, data->allow_intr, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
         data->result = 0;
         return GTKML_VISIT_BREAK;
     }
@@ -3010,7 +3168,7 @@ GTKML_PRIVATE GtkMl_VisitResult compile_set(GtkMl_HashSet *hs, void *key_ptr, vo
     GtkMl_S *key = key_ptr;
 
     struct CompileData *data = _data;
-    if (!compile_macro_expression(data->ctx, data->b, data->basic_block, data->err, &key, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
+    if (!compile_expression(data->ctx, data->b, data->basic_block, data->err, &key, data->allow_intr, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
         data->result = 0;
         return GTKML_VISIT_BREAK;
     }
@@ -3022,22 +3180,22 @@ GTKML_PRIVATE GtkMl_VisitResult compile_array(GtkMl_Array *array, size_t idx, Gt
     (void) idx;
 
     struct CompileData *data = _data;
-    if (!compile_macro_expression(data->ctx, data->b, data->basic_block, data->err, &value, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
+    if (!compile_expression(data->ctx, data->b, data->basic_block, data->err, &value, data->allow_intr, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
         data->result = 0;
         return GTKML_VISIT_BREAK;
     }
     return GTKML_VISIT_RECURSE;
 }
 
-gboolean compile_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt) {
-    return compile_macro_expression(ctx, b, basic_block, err, stmt, 0, 1, 1);
+gboolean compile_runtime_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt) {
+    return compile_expression(ctx, b, basic_block, err, stmt, 0, 0, 1, 1);
 }
 
-gboolean compile_program(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, const char *linkage_name, GtkMl_S *lambda, gboolean ret) {
-    return compile_macro_program(ctx, b, basic_block, err, linkage_name, lambda, ret, 0, 1, 1);
+gboolean compile_runtime_program(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, const char *linkage_name, GtkMl_S *lambda, gboolean ret) {
+    return compile_program(ctx, b, basic_block, err, linkage_name, lambda, ret, 0, 0, 1, 1);
 }
 
-gboolean compile_macro_quasi_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S *stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean compile_quasi_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S *stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     switch (stmt->kind) {
     case GTKML_S_NIL:
     case GTKML_S_TRUE:
@@ -3060,24 +3218,24 @@ gboolean compile_macro_quasi_expression(GtkMl_Context *ctx, GtkMl_Builder *b, Gt
         return gtk_ml_build_push_extended_imm(ctx, b, *basic_block, err, gtk_ml_append_static(b, stmt));
     case GTKML_S_MAP: {
         int64_t n = gtk_ml_hash_trie_len(&stmt->value.s_map.map);
-        struct CompileData data = { ctx, b, basic_block, err, stmt, allow_macro, allow_runtime, allow_macro_expansion, 1 }; 
+        struct CompileData data = { ctx, b, basic_block, err, stmt, allow_intr, allow_macro, allow_runtime, allow_macro_expansion, 1 }; 
         gtk_ml_hash_trie_foreach(&stmt->value.s_map.map, compile_quasi_map, &data);
         return gtk_ml_build_map_extended_imm(ctx, b, *basic_block, err, gtk_ml_append_static(b, new_int(ctx, NULL, n)));
     }
     case GTKML_S_SET: {
         int64_t n = gtk_ml_hash_set_len(&stmt->value.s_set.set);
-        struct CompileData data = { ctx, b, basic_block, err, stmt, allow_macro, allow_runtime, allow_macro_expansion, 1 }; 
+        struct CompileData data = { ctx, b, basic_block, err, stmt, allow_intr, allow_macro, allow_runtime, allow_macro_expansion, 1 }; 
         gtk_ml_hash_set_foreach(&stmt->value.s_set.set, compile_quasi_set, &data);
         return gtk_ml_build_set_extended_imm(ctx, b, *basic_block, err, gtk_ml_append_static(b, new_int(ctx, NULL, n)));
     }
     case GTKML_S_ARRAY: {
         int64_t n = gtk_ml_array_len(&stmt->value.s_array.array);
-        struct CompileData data = { ctx, b, basic_block, err, stmt, allow_macro, allow_runtime, allow_macro_expansion, 1 }; 
+        struct CompileData data = { ctx, b, basic_block, err, stmt, allow_intr, allow_macro, allow_runtime, allow_macro_expansion, 1 }; 
         gtk_ml_array_foreach(&stmt->value.s_array.array, compile_quasi_array, &data);
         return gtk_ml_build_array_extended_imm(ctx, b, *basic_block, err, gtk_ml_append_static(b, new_int(ctx, NULL, n)));
     }
     case GTKML_S_UNQUOTE:
-        return compile_macro_expression(ctx, b, basic_block, err, &stmt->value.s_unquote.expr, allow_macro, allow_runtime, allow_macro_expansion);
+        return compile_expression(ctx, b, basic_block, err, &stmt->value.s_unquote.expr, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
     case GTKML_S_LIST: {
         GtkMl_S *function = gtk_ml_car(stmt);
 
@@ -3093,13 +3251,13 @@ gboolean compile_macro_quasi_expression(GtkMl_Context *ctx, GtkMl_Builder *b, Gt
                     return 0;
                 }
 
-                return compile_macro_expression(ctx, b, basic_block, err, &gtk_ml_car(args), allow_macro, allow_runtime, allow_macro_expansion);
+                return compile_expression(ctx, b, basic_block, err, &gtk_ml_car(args), allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
             }
         }
 
         int64_t n = 0;
         while (stmt->kind != GTKML_S_NIL) {
-            if (!compile_macro_quasi_expression(ctx, b, basic_block, err, gtk_ml_car(stmt), allow_macro, allow_runtime, allow_macro_expansion)) {
+            if (!compile_quasi_expression(ctx, b, basic_block, err, gtk_ml_car(stmt), allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
                 return 0;
             }
             stmt = gtk_ml_cdr(stmt);
@@ -3110,7 +3268,7 @@ gboolean compile_macro_quasi_expression(GtkMl_Context *ctx, GtkMl_Builder *b, Gt
     }
 }
 
-gboolean compile_macro_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean compile_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     switch ((*stmt)->kind) {
     case GTKML_S_NIL:
     case GTKML_S_TRUE:
@@ -3130,7 +3288,7 @@ gboolean compile_macro_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_Ba
         char *linkage_name = malloc(strlen("lambda$") + 16);
         snprintf(linkage_name, strlen("lambda$") + 16, "lambda$%u", b->counter++);
         GtkMl_BasicBlock *bb = gtk_ml_append_basic_block(b, linkage_name);
-        if (!compile_macro_program(ctx, b, &bb, err, linkage_name, *stmt, 1, allow_macro, allow_runtime, allow_macro_expansion)) {
+        if (!compile_program(ctx, b, &bb, err, linkage_name, *stmt, 1, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
             return 0;
         }
         return gtk_ml_build_push_extended_addr(ctx, b, *basic_block, err, gtk_ml_append_static(b, new_string(ctx, NULL, linkage_name, strlen(linkage_name))));
@@ -3139,31 +3297,31 @@ gboolean compile_macro_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_Ba
         char *linkage_name = malloc(strlen("macro$") + 16);
         snprintf(linkage_name, strlen("macro$") + 16, "macro$%u", b->counter++);
         GtkMl_BasicBlock *bb = gtk_ml_append_basic_block(b, linkage_name);
-        if (!compile_macro_program(ctx, b, &bb, err, linkage_name, *stmt, 1, allow_macro, allow_runtime, allow_macro_expansion)) {
+        if (!compile_program(ctx, b, &bb, err, linkage_name, *stmt, 1, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
             return 0;
         }
         return gtk_ml_build_push_extended_addr(ctx, b, *basic_block, err, gtk_ml_append_static(b, new_string(ctx, NULL, linkage_name, strlen(linkage_name))));
     }
     case GTKML_S_MAP: {
         int64_t n = gtk_ml_hash_trie_len(&(*stmt)->value.s_map.map);
-        struct CompileData data = { ctx, b, basic_block, err, (*stmt), allow_macro, allow_runtime, allow_macro_expansion, 1 }; 
+        struct CompileData data = { ctx, b, basic_block, err, (*stmt), allow_intr, allow_macro, allow_runtime, allow_macro_expansion, 1 }; 
         gtk_ml_hash_trie_foreach(&(*stmt)->value.s_map.map, compile_map, &data);
         return gtk_ml_build_map_extended_imm(ctx, b, *basic_block, err, gtk_ml_append_static(b, new_int(ctx, NULL, n)));
     }
     case GTKML_S_SET: {
         int64_t n = gtk_ml_hash_set_len(&(*stmt)->value.s_set.set);
-        struct CompileData data = { ctx, b, basic_block, err, (*stmt), allow_macro, allow_runtime, allow_macro_expansion, 1 }; 
+        struct CompileData data = { ctx, b, basic_block, err, (*stmt), allow_intr, allow_macro, allow_runtime, allow_macro_expansion, 1 }; 
         gtk_ml_hash_set_foreach(&(*stmt)->value.s_set.set, compile_set, &data);
         return gtk_ml_build_set_extended_imm(ctx, b, *basic_block, err, gtk_ml_append_static(b, new_int(ctx, NULL, n)));
     }
     case GTKML_S_ARRAY: {
         int64_t n = gtk_ml_array_len(&(*stmt)->value.s_array.array);
-        struct CompileData data = { ctx, b, basic_block, err, (*stmt), allow_macro, allow_runtime, allow_macro_expansion, 1 }; 
+        struct CompileData data = { ctx, b, basic_block, err, (*stmt), allow_intr, allow_macro, allow_runtime, allow_macro_expansion, 1 }; 
         gtk_ml_array_foreach(&(*stmt)->value.s_array.array, compile_array, &data);
         return gtk_ml_build_array_extended_imm(ctx, b, *basic_block, err, gtk_ml_append_static(b, new_int(ctx, NULL, n)));
     }
     case GTKML_S_VAR:
-        compile_macro_expression(ctx, b, basic_block, err, &(*stmt)->value.s_var.expr, allow_macro, allow_runtime, allow_macro_expansion);
+        compile_expression(ctx, b, basic_block, err, &(*stmt)->value.s_var.expr, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
         return gtk_ml_build_var_imm(ctx, b, *basic_block, err);
     case GTKML_S_VARARG:
         *err = gtk_ml_error(ctx, "unimplemented", GTKML_ERR_UNIMPLEMENTED, (*stmt)->span.ptr != NULL, (*stmt)->span.line, (*stmt)->span.col, 0);
@@ -3171,7 +3329,7 @@ gboolean compile_macro_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_Ba
     case GTKML_S_QUOTE:
         return gtk_ml_build_push_extended_imm(ctx, b, *basic_block, err, gtk_ml_append_static(b, (*stmt)->value.s_quote.expr));
     case GTKML_S_QUASIQUOTE:
-        return compile_macro_quasi_expression(ctx, b, basic_block, err, (*stmt)->value.s_quasiquote.expr, allow_macro, allow_runtime, allow_macro_expansion);
+        return compile_quasi_expression(ctx, b, basic_block, err, (*stmt)->value.s_quasiquote.expr, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
     case GTKML_S_UNQUOTE:
         *err = gtk_ml_error(ctx, "unquote-error", GTKML_ERR_UNQUOTE_ERROR, (*stmt)->span.ptr != NULL, (*stmt)->span.line, (*stmt)->span.col, 0);
         return 0;
@@ -3186,18 +3344,39 @@ gboolean compile_macro_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_Ba
             for (size_t i = 0; i < b->len_builder; i++) {
                 GtkMl_BuilderMacro *bm = b->builders + i;
                 if (strlen(bm->name) == len && strncmp(bm->name, ptr, len) == 0) {
-                    if (bm->require_macro) {
+                    if (bm->require_intrinsic) {
+                        if (allow_intr) {
+                            return bm->fn(ctx, b, basic_block, err, stmt, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
+                        }
+                    } else if (bm->require_macro) {
                         if (allow_macro) {
-                            return bm->fn(ctx, b, basic_block, err, stmt, allow_macro, allow_runtime, allow_macro_expansion);
+                            return bm->fn(ctx, b, basic_block, err, stmt, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
                         }
                     } else if (bm->require_runtime) {
                         if (allow_runtime) {
-                            return bm->fn(ctx, b, basic_block, err, stmt, allow_macro, allow_runtime, allow_macro_expansion);
+                            return bm->fn(ctx, b, basic_block, err, stmt, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
                         }
                     } else {
-                        return bm->fn(ctx, b, basic_block, err, stmt, allow_macro, allow_runtime, allow_macro_expansion);
+                        return bm->fn(ctx, b, basic_block, err, stmt, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
                     }
                 }
+            }
+        }
+
+        if (!allow_intr && (*function)->kind == GTKML_S_SYMBOL) {
+            size_t len = (*function)->value.s_symbol.len;
+            char *linkage_name = malloc(len + 1);
+            memcpy(linkage_name, (*function)->value.s_symbol.ptr, len);
+            linkage_name[len] = 0;
+
+            GtkMl_S *_err = NULL;
+            GtkMl_S *program = gtk_ml_get_export(b->intr_ctx, &_err, linkage_name);
+            free(linkage_name);
+            if (program) {
+                gtk_ml_define(b->intr_ctx, new_symbol(ctx, NULL, 0, "CTX", strlen("CTX")), new_lightdata(ctx, NULL, ctx));
+                gtk_ml_define(b->intr_ctx, new_symbol(ctx, NULL, 0, "CODE-BUILDER", strlen("CODE-BUILDER")), new_lightdata(ctx, NULL, b));
+                gtk_ml_define(b->intr_ctx, new_symbol(ctx, NULL, 0, "BASIC-BLOCK", strlen("BASIC-BLOCK")), new_lightdata(ctx, NULL, basic_block));
+                return gtk_ml_run_program(b->intr_ctx, err, program, args);
             }
         }
 
@@ -3223,14 +3402,14 @@ gboolean compile_macro_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_Ba
 
                 *stmt = result;
 
-                return compile_macro_expression(ctx, b, basic_block, err, stmt, allow_macro, allow_runtime, allow_macro_expansion);
+                return compile_expression(ctx, b, basic_block, err, stmt, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
             }
         }
 
         int64_t n_args = 0;
         while (args->kind != GTKML_S_NIL) {
             GtkMl_S **arg = &gtk_ml_car(args);
-            if (!compile_macro_expression(ctx, b, basic_block, err, arg, allow_macro, allow_runtime, allow_macro_expansion)) {
+            if (!compile_expression(ctx, b, basic_block, err, arg, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
                 return 0;
             }
             ++n_args;
@@ -3241,7 +3420,7 @@ gboolean compile_macro_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_Ba
             return 0;
         }
 
-        if (!compile_macro_expression(ctx, b, basic_block, err, function, allow_macro, allow_runtime, allow_macro_expansion)) {
+        if (!compile_expression(ctx, b, basic_block, err, function, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
             return 0;
         }
 
@@ -3250,10 +3429,10 @@ gboolean compile_macro_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_Ba
     }
 }
 
-gboolean compile_macro_body(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S *body, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean compile_body(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S *body, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     while (body->kind != GTKML_S_NIL) {
         GtkMl_S **stmt = &gtk_ml_car(body);
-        if (!compile_macro_expression(ctx, b, basic_block, err, stmt, allow_macro, allow_runtime, allow_macro_expansion)) {
+        if (!compile_expression(ctx, b, basic_block, err, stmt, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
             return 0;
         }
         body = gtk_ml_cdr(body);
@@ -3262,7 +3441,7 @@ gboolean compile_macro_body(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlo
     return 1;
 }
 
-gboolean compile_macro_program(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, const char *linkage_name, GtkMl_S *lambda, gboolean ret, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean compile_program(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, const char *linkage_name, GtkMl_S *lambda, gboolean ret, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     if ((!allow_macro || lambda->kind != GTKML_S_MACRO) && lambda->kind != GTKML_S_LAMBDA) {
         *err = gtk_ml_error(ctx, "program-error", GTKML_ERR_PROGRAM_ERROR, lambda->span.ptr != NULL, lambda->span.line, lambda->span.col, 0);
         return 0;
@@ -3304,7 +3483,7 @@ gboolean compile_macro_program(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_Basic
         return 0;
     }
 
-    if (!compile_macro_body(ctx, b, basic_block, err, lambda->value.s_lambda.body, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_body(ctx, b, basic_block, err, lambda->value.s_lambda.body, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
 
@@ -4192,6 +4371,52 @@ gboolean gtk_ml_build_bitxor(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBl
     return 1;
 }
 
+gboolean gtk_ml_compile_intrinsics(GtkMl_Builder *b, GtkMl_S **err, GtkMl_S *lambda) {
+    GtkMl_S *prev = lambda->value.s_lambda.body;
+    GtkMl_S *next = prev;
+    while (next->kind != GTKML_S_NIL) {
+        GtkMl_S *stmt = gtk_ml_car(next);
+
+        GtkMl_S *function = gtk_ml_car(stmt);
+
+        GtkMl_S *args = gtk_ml_cdr(stmt);
+
+        if (function->kind == GTKML_S_SYMBOL) {
+            const char *symbol_define_intrinsic = "define-intrinsic";
+
+            if (function->value.s_symbol.len == strlen(symbol_define_intrinsic)
+                    && memcmp(function->value.s_symbol.ptr, symbol_define_intrinsic, function->value.s_symbol.len) == 0) {
+                GtkMl_S *intrinsic_definition = gtk_ml_car(args);
+                GtkMl_S *intrinsic_name = gtk_ml_car(intrinsic_definition);
+                GtkMl_S *intrinsic_args = gtk_ml_cdr(intrinsic_definition);
+                GtkMl_S *intrinsic_body = gtk_ml_cdr(args);
+
+                GtkMl_S *intrinsic = new_lambda(b->intr_ctx, NULL, intrinsic_args, intrinsic_body, local_scope(b->intr_ctx));
+                if (!intrinsic) {
+                    return 0;
+                }
+
+                size_t len = intrinsic_name->value.s_symbol.len;
+                char *linkage_name = malloc(len + 1);
+                memcpy(linkage_name, intrinsic_name->value.s_symbol.ptr, len);
+                linkage_name[len] = 0;
+
+                GtkMl_BasicBlock *basic_block = gtk_ml_append_basic_block(b, linkage_name);
+
+                if (!compile_program(b->intr_ctx, b, &basic_block, err, linkage_name, intrinsic, 1, 1, 0, 0, 0)) {
+                    free(linkage_name);
+                    return 0;
+                }
+
+                free(linkage_name);
+            }
+        }
+        next = gtk_ml_cdr(next);
+    }
+    
+    return 1;
+}
+
 gboolean gtk_ml_compile_macros(GtkMl_Builder *b, GtkMl_S **err, GtkMl_S *lambda) {
     GtkMl_S *prev = lambda->value.s_lambda.body;
     GtkMl_S *next = prev;
@@ -4224,7 +4449,7 @@ gboolean gtk_ml_compile_macros(GtkMl_Builder *b, GtkMl_S **err, GtkMl_S *lambda)
 
                 GtkMl_BasicBlock *basic_block = gtk_ml_append_basic_block(b, linkage_name);
 
-                if (!compile_macro_program(b->macro_ctx, b, &basic_block, err, linkage_name, macro, 1, 1, 0, 0)) {
+                if (!compile_program(b->macro_ctx, b, &basic_block, err, linkage_name, macro, 1, 0, 1, 0, 0)) {
                     free(linkage_name);
                     return 0;
                 }
@@ -4242,7 +4467,7 @@ gboolean gtk_ml_compile(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S **err, Gtk
     const char *linkage_name = "_start";
     GtkMl_BasicBlock *basic_block = gtk_ml_append_basic_block(b, linkage_name);
 
-    if (!compile_program(ctx, b, &basic_block, err, linkage_name, lambda, 0)) {
+    if (!compile_runtime_program(ctx, b, &basic_block, err, linkage_name, lambda, 0)) {
         return 0;
     }
 
@@ -4254,6 +4479,16 @@ gboolean gtk_ml_compile(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S **err, Gtk
 }
 
 gboolean gtk_ml_compile_program(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S **err, GtkMl_S *lambda) {
+    if (!gtk_ml_compile_intrinsics(b, err, lambda)) {
+        return 0;
+    }
+    GtkMl_Program intrinsics;
+    if (!gtk_ml_build_intrinsics(&intrinsics, err, b)) {
+        return 0;
+    }
+    gtk_ml_load_program(b->intr_ctx, &intrinsics);
+    gtk_ml_del_program(&intrinsics);
+
     if (!gtk_ml_compile_macros(b, err, lambda)) {
         return 0;
     }
@@ -4263,6 +4498,7 @@ gboolean gtk_ml_compile_program(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S **
     }
     gtk_ml_load_program(b->macro_ctx, &macros);
     gtk_ml_del_program(&macros);
+
     return gtk_ml_compile(ctx, b, err, lambda);
 }
 
@@ -4996,6 +5232,38 @@ GTKML_PRIVATE GtkMl_S *vm_std_error(GtkMl_Context *ctx, GtkMl_S **err, GtkMl_S *
     *err = error_expr;
 
     return NULL;
+}
+
+GTKML_PRIVATE GtkMl_S *vm_std_compile_expr(GtkMl_Context *ctx, GtkMl_S **err, GtkMl_S *expr) {
+    (void) expr;
+    GtkMl_S *arg = gtk_ml_pop(ctx);
+    GtkMl_BasicBlock **arg_basic_block = gtk_ml_pop(ctx)->value.s_lightdata.userdata;
+    GtkMl_Builder *arg_b = gtk_ml_pop(ctx)->value.s_lightdata.userdata;
+    GtkMl_Context *arg_ctx = gtk_ml_pop(ctx)->value.s_lightdata.userdata;
+
+    return compile_expression(arg_ctx, arg_b, arg_basic_block, err, &arg, 0, 0, 1, 1)? new_true(ctx, NULL) : NULL;
+}
+
+GTKML_PRIVATE GtkMl_S *vm_std_emit_bytecode(GtkMl_Context *ctx, GtkMl_S **err, GtkMl_S *expr) {
+    (void) expr;
+
+    GtkMl_S *bc = gtk_ml_pop(ctx);
+    unsigned int arg_cond = gtk_ml_pop(ctx)->value.s_int.value;
+    GtkMl_BasicBlock **arg_basic_block = gtk_ml_pop(ctx)->value.s_lightdata.userdata;
+    GtkMl_Builder *arg_b = gtk_ml_pop(ctx)->value.s_lightdata.userdata;
+    GtkMl_Context *arg_ctx = gtk_ml_pop(ctx)->value.s_lightdata.userdata;
+    const char *bc_ptr = bc->value.s_keyword.ptr;
+    size_t bc_len = bc->value.s_keyword.len;
+
+    const char *bc_add = "add";
+
+    if (strlen(bc_add) == bc_len && strncmp(bc_ptr, bc_add, bc_len) == 0) {
+        gtk_ml_builder_set_cond(arg_b, arg_cond);
+        return gtk_ml_build_add(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else {
+        *err = gtk_ml_error(ctx, "bytecode-error", GTKML_ERR_BYTECODE_ERROR, bc->span.ptr != NULL, bc->span.line, bc->span.col, 0);
+        return NULL;
+    }
 }
 
 gboolean gtk_ml_equal(GtkMl_S *lhs, GtkMl_S *rhs) {
@@ -6270,14 +6538,6 @@ gboolean gtk_ml_eii_cmp_ext_imm(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction i
 
     GtkMl_S *lhs = gtk_ml_pop(vm->ctx);
     GtkMl_S *rhs = gtk_ml_pop(vm->ctx);
-
-    printf("(cmp ");
-    gtk_ml_dumpf(vm->ctx, stdout, NULL, imm64);
-    printf(" ");
-    gtk_ml_dumpf(vm->ctx, stdout, NULL, lhs);
-    printf(" ");
-    gtk_ml_dumpf(vm->ctx, stdout, NULL, rhs);
-    printf(")\n");
 
     switch (cmp) {
     case GTKML_CMP_EQUAL:


### PR DESCRIPTION
Closes #24 

This commit implements user-defined intrinsics. Intrinsics are functions that are evaluated before macros are evaluated and are ran during code generation. An intrinsic has complete power over the code generation stage, being able to modify the context (`CTX` global), the builder (`CODE-BUILDER` global) and the current basic block (`BASIC-BLOCK` global). This makes it possible to emit bytecodes and potentially manipulate other aspects of the program being generated.

The current syntax and semantics look like this:

```clojure
(define-intrinsic (intr-add a b)
  (compile-expr CTX CODE-BUILDER BASIC-BLOCK b)
  (compile-expr CTX CODE-BUILDER BASIC-BLOCK a)
  (emit-bytecode CTX CODE-BUILDER BASIC-BLOCK cond-none :add))
```