### PR TITLE
Improvement: more bytecodes and special forms

### DIFF
--- a/examples/hello.gtkml
+++ b/examples/hello.gtkml
@@ -1,8 +1,13 @@
+(define (number? expr) #t)
+
 ; define an intrinsical operator
 (define-intrinsic (intr-add a b)
-  (compile-expr CTX CODE-BUILDER BASIC-BLOCK b)
-  (compile-expr CTX CODE-BUILDER BASIC-BLOCK a)
-  (emit-bytecode CTX CODE-BUILDER BASIC-BLOCK cond-none :add))
+  (cond
+    (number? a) (do
+      (compile-expr CTX CODE-BUILDER BASIC-BLOCK b)
+      (compile-expr CTX CODE-BUILDER BASIC-BLOCK a)
+      (emit-bytecode CTX CODE-BUILDER BASIC-BLOCK cond-none :add))
+    :else (error {:err 'number-error :desc "not a number"})))
 
 ; define a Window macro
 (define-macro (Window title width height)

--- a/examples/hello.gtkml
+++ b/examples/hello.gtkml
@@ -1,13 +1,49 @@
-(define (number? expr) #t)
+(define (= a b) (cmp 0 a b))
+(define (cdar list) (car (cdr list)))
+(define (cddar list) (car (cdr (cdr list))))
+
+; returns true if expression is an int or a float
+(define (number? expr)
+  (cond
+    (= (typeof expr) :int)   #t
+    (= (typeof expr) :float) #t
+    :else                    #f))
+
+; returns true if expression is a non-empty list
+(define (list? expr) (= (typeof expr) :list))
+
+; returns true if expression is a constant number or an expression that evaluates to a constant number
+(define (const-number? expr)
+  (cond
+    (number? expr) #t
+    (list? expr)   (cond
+      (= (car expr) 'intr-add) (cond
+        (const-number? (cdar expr)) (const-number (cddar expr))
+        :else #f))
+    :else          #f))
+
+; evaluates a constant expression
+(define (const-eval expr)
+  (cond
+    (number? expr) expr
+    (list? expr)   (cond
+      (= (car expr) 'intr-add) (+ (const-eval (cdar expr)) (const-eval (cddar expr)))
+      :else                    #nil)
+    :else          expr))
 
 ; define an intrinsical operator
 (define-intrinsic (intr-add a b)
   (cond
-    (number? a) (do
+    (const-number? a) (cond
+      (const-number? b) (emit-bytecode CTX CODE-BUILDER BASIC-BLOCK cond-none :push-imm (+ (const-eval a) (const-eval b)))
+      :else (do
+        (compile-expr CTX CODE-BUILDER BASIC-BLOCK b)
+        (compile-expr CTX CODE-BUILDER BASIC-BLOCK a)
+        (emit-bytecode CTX CODE-BUILDER BASIC-BLOCK cond-none :add)))
+    :else (do
       (compile-expr CTX CODE-BUILDER BASIC-BLOCK b)
       (compile-expr CTX CODE-BUILDER BASIC-BLOCK a)
-      (emit-bytecode CTX CODE-BUILDER BASIC-BLOCK cond-none :add))
-    :else (error {:err 'number-error :desc "not a number"})))
+      (emit-bytecode CTX CODE-BUILDER BASIC-BLOCK cond-none :add))))
 
 ; define a Window macro
 (define-macro (Window title width height)

--- a/examples/hello.gtkml
+++ b/examples/hello.gtkml
@@ -1,14 +1,20 @@
+; define an intrinsical operator
+(define-intrinsic (intr-add a b)
+  (compile-expr CTX CODE-BUILDER BASIC-BLOCK b)
+  (compile-expr CTX CODE-BUILDER BASIC-BLOCK a)
+  (emit-bytecode CTX CODE-BUILDER BASIC-BLOCK cond-none :add))
+
 ; define a Window macro
 (define-macro (Window title width height)
   `(lambda (app)
     (new-window app ,title ,width ,height)))
-(define (add a b) (+ a b))
+
 ; run the application
 (Application "de.walterpi.example" flags-none {
   :activate (Window
     "gtk-ml example"
     (cond
-      #f         (error {:err 'cond-error :desc "cond evaluated in an incorrect way"})
-     (cmp 0 1 2) (error {:err 'cond-error :desc "cond evaluated in an incorrect way"})
-      :else      640)
-    (do 0 (add 240 240)))})
+      #f          (error {:err 'cond-error :desc "cond evaluated in an incorrect way"})
+      (cmp 0 1 2) (error {:err 'cond-error :desc "cond evaluated in an incorrect way"})
+      :else       640)
+    (do 0 (intr-add 240 240)))})

--- a/include/gtk-ml.h
+++ b/include/gtk-ml.h
@@ -447,6 +447,12 @@ typedef struct GtkMl_SLambda {
     GtkMl_S *capture;
 } GtkMl_SLambda;
 
+typedef enum GtkMl_ProgramKind {
+    GTKML_PROG_INTRINSIC,
+    GTKML_PROG_MACRO,
+    GTKML_PROG_RUNTIME,
+} GtkMl_ProgramKind;
+
 // a compiled closure
 typedef struct GtkMl_SProgram {
     const char *linkage_name;
@@ -454,6 +460,7 @@ typedef struct GtkMl_SProgram {
     GtkMl_S *args;
     GtkMl_S *body;
     GtkMl_S *capture;
+    GtkMl_ProgramKind kind;
 } GtkMl_SProgram;
 
 // a compiled closure

--- a/include/gtk-ml.h
+++ b/include/gtk-ml.h
@@ -79,9 +79,14 @@ typedef enum GtkMl_Cmp {
 #define GTKML_IA_BIT_NAND 0x24
 #define GTKML_IA_BIT_NOR 0x25
 #define GTKML_IA_BIT_XNOR 0x26
+#define GTKML_IA_CAR 0x30
+#define GTKML_IA_CDR 0x31
 #define GTKML_IA_BIND 0x50
 #define GTKML_IA_DEFINE 0x51
 #define GTKML_IA_BIND_ARGS 0x52
+#define GTKML_IA_ENTER 0x5e
+#define GTKML_IA_LEAVE 0x5f
+#define GTKML_IA_TYPEOF 0xf0
 
 #define GTKML_II_PUSH_IMM 0x0
 #define GTKML_II_POP 0x1
@@ -145,9 +150,14 @@ typedef enum GtkMl_Cmp {
 #define GTKML_SIA_BIT_NAND "BIT_NAND"
 #define GTKML_SIA_BIT_NOR "BIT_NOR"
 #define GTKML_SIA_BIT_XNOR "BIT_XNOR"
+#define GTKML_SIA_CAR "CAR"
+#define GTKML_SIA_CDR "CDR"
 #define GTKML_SIA_BIND "BIND"
 #define GTKML_SIA_DEFINE "DEFINE"
 #define GTKML_SIA_BIND_ARGS "BIND_ARGS"
+#define GTKML_SIA_TYPEOF "TYPEOF"
+#define GTKML_SIA_ENTER "ENTER"
+#define GTKML_SIA_LEAVE "LEAVE"
 
 #define GTKML_SII_PUSH_IMM_EXTERN "PUSH_IMM EXTERN"
 #define GTKML_SII_PUSH_IMM "PUSH_IMM"
@@ -663,9 +673,19 @@ GTKML_PUBLIC gboolean gtk_ml_build_popf(GtkMl_Context *ctx, GtkMl_Builder *b, Gt
 // builds a push in the chosen basic_block
 GTKML_PUBLIC gboolean gtk_ml_build_define(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err);
 // builds a push in the chosen basic_block
+GTKML_PUBLIC gboolean gtk_ml_build_car(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err);
+// builds a push in the chosen basic_block
+GTKML_PUBLIC gboolean gtk_ml_build_cdr(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err);
+// builds a push in the chosen basic_block
 GTKML_PUBLIC gboolean gtk_ml_build_bind(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err);
 // builds a push in the chosen basic_block
 GTKML_PUBLIC gboolean gtk_ml_build_bind_args(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err);
+// builds a push in the chosen basic_block
+GTKML_PUBLIC gboolean gtk_ml_build_enter(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err);
+// builds a push in the chosen basic_block
+GTKML_PUBLIC gboolean gtk_ml_build_leave(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err);
+// builds a push in the chosen basic_block
+GTKML_PUBLIC gboolean gtk_ml_build_typeof(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err);
 // builds a push in the chosen basic_block
 GTKML_PUBLIC gboolean gtk_ml_build_get_extended_imm(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err, GtkMl_Static imm64);
 // builds a push in the chosen basic_block

--- a/include/gtk-ml.h
+++ b/include/gtk-ml.h
@@ -36,6 +36,8 @@
 #define GTKML_STD_APPLICATION 0x0
 #define GTKML_STD_NEW_WINDOW 0x1
 #define GTKML_STD_ERROR 0x2
+#define GTKML_STD_COMPILE_EXPR 0x100
+#define GTKML_STD_EMIT_BYTECODE 0x101
 
 #define GTKML_I_ARITH 0x1
 #define GTKML_I_IMM 0x2
@@ -194,6 +196,7 @@ typedef enum GtkMl_Cmp {
 #define GTKML_ERR_ARGUMENT_ERROR "invalid arguments"
 #define GTKML_ERR_TYPE_ERROR "invalid type for expression"
 #define GTKML_ERR_CMP_ERROR "invalid comparison enum"
+#define GTKML_ERR_BYTECODE_ERROR "unrecognized bytecode keyword"
 #define GTKML_ERR_BOOLEAN_ERROR "expected a boolean expression"
 #define GTKML_ERR_ARITY_ERROR "invalid argument count"
 #define GTKML_ERR_BINDING_ERROR "binding not found"
@@ -228,6 +231,12 @@ typedef struct GtkMl_Builder GtkMl_Builder;
 typedef union GtkMl_Register GtkMl_Register;
 typedef uint64_t GtkMl_Static;
 typedef uint32_t GtkMl_Hash;
+
+typedef enum GtkMl_Stage {
+    GTKML_STAGE_INTR,
+    GTKML_STAGE_MACRO,
+    GTKML_STAGE_RUNTIME,
+} GtkMl_Stage;
 
 // a lexical analysis level token tag
 typedef enum GtkMl_TokenKind {
@@ -519,11 +528,12 @@ typedef struct GtkMl_BasicBlock {
     size_t cap_exec;
 } GtkMl_BasicBlock;
 
-typedef gboolean (*GtkMl_BuilderFn)(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+typedef gboolean (*GtkMl_BuilderFn)(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
 
 typedef struct GtkMl_BuilderMacro {
     const char *name;
     GtkMl_BuilderFn fn;
+    gboolean require_intrinsic;
     gboolean require_macro;
     gboolean require_runtime;
 } GtkMl_BuilderMacro;
@@ -539,6 +549,9 @@ struct GtkMl_Builder {
 
     unsigned int counter;
     unsigned int flags;
+
+    GtkMl_Context *intr_ctx;
+    GtkMl_Vm *intr_vm;
 
     GtkMl_Context *macro_ctx;
     GtkMl_Vm *macro_vm;
@@ -703,8 +716,8 @@ GTKML_PUBLIC GtkMl_S *gtk_ml_loadf(GtkMl_Context *ctx, char **src, GtkMl_S **err
 // loads an expression from a string
 GTKML_PUBLIC GtkMl_S *gtk_ml_loads(GtkMl_Context *ctx, GtkMl_S **err, const char *src);
 
-// do a macro pass on the selected lambda expression
-GTKML_PUBLIC gboolean gtk_ml_macro_pass(GtkMl_Builder *b, GtkMl_S **err, GtkMl_S *lambda);
+// compile a lambda expression to bytecode
+GTKML_PUBLIC gboolean gtk_ml_compile_intrinsics(GtkMl_Builder *b, GtkMl_S **err, GtkMl_S *intrinsic);
 // compile a lambda expression to bytecode
 GTKML_PUBLIC gboolean gtk_ml_compile_macros(GtkMl_Builder *b, GtkMl_S **err, GtkMl_S *macro);
 // compile a lambda expression to bytecode

--- a/include/gtk-ml.h
+++ b/include/gtk-ml.h
@@ -559,6 +559,9 @@ struct GtkMl_Builder {
     GtkMl_BuilderMacro *builders;
     size_t len_builder;
     size_t cap_builder;
+
+    GtkMl_HashSet intr_fns;
+    GtkMl_HashSet macro_fns;
 };
 
 union GtkMl_Register {

--- a/include/gtk-ml.h
+++ b/include/gtk-ml.h
@@ -97,6 +97,16 @@ typedef enum GtkMl_Cmp {
 #define GTKML_II_VAR_IMM 0x16
 #define GTKML_II_GETVAR_IMM 0x17
 #define GTKML_II_ASSIGNVAR_IMM 0x18
+#define GTKML_II_LEN 0x19
+#define GTKML_II_ARRAY_INDEX 0x1a
+#define GTKML_II_ARRAY_PUSH 0x1b
+#define GTKML_II_ARRAY_POP 0x1c
+#define GTKML_II_MAP_GET 0x1d
+#define GTKML_II_MAP_INSERT 0x1f
+#define GTKML_II_MAP_DELETE 0x20
+#define GTKML_II_SET_CONTAINS 0x21
+#define GTKML_II_SET_INSERT 0x22
+#define GTKML_II_SET_DELETE 0x23
 
 #define GTKML_IBR_CALL 0x1
 #define GTKML_IBR_RET 0x2
@@ -154,6 +164,16 @@ typedef enum GtkMl_Cmp {
 #define GTKML_SII_VAR_IMM "VAR_IMM"
 #define GTKML_SII_GETVAR_IMM "GETVAR_IMM"
 #define GTKML_SII_ASSIGNVAR_IMM "ASSIGNVAR_IMM"
+#define GTKML_SII_LEN "LEN"
+#define GTKML_SII_ARRAY_INDEX "ARRAY_INDEX"
+#define GTKML_SII_ARRAY_PUSH "ARRAY_PUSH"
+#define GTKML_SII_ARRAY_POP "ARRAY_POP"
+#define GTKML_SII_MAP_GET "MAP_GET"
+#define GTKML_SII_MAP_INSERT "MAP_INSERT"
+#define GTKML_SII_MAP_DELETE "MAP_DELETE"
+#define GTKML_SII_SET_CONTAINS "SET_CONTAINS"
+#define GTKML_SII_SET_INSERT "SET_INSERT"
+#define GTKML_SII_SET_DELETE "SET_DELETE"
 
 #define GTKML_SIBR_CALL_STD "CALL_STD"
 #define GTKML_SIBR_CALL "CALL"
@@ -195,6 +215,7 @@ typedef enum GtkMl_Cmp {
 #define GTKML_ERR_INVALID_SEXPR "invalid s-expression"
 #define GTKML_ERR_ARGUMENT_ERROR "invalid arguments"
 #define GTKML_ERR_TYPE_ERROR "invalid type for expression"
+#define GTKML_ERR_CONTAINER_ERROR "not a container"
 #define GTKML_ERR_CMP_ERROR "invalid comparison enum"
 #define GTKML_ERR_BYTECODE_ERROR "unrecognized bytecode keyword"
 #define GTKML_ERR_BOOLEAN_ERROR "expected a boolean expression"
@@ -675,6 +696,26 @@ GTKML_PUBLIC gboolean gtk_ml_build_var_imm(GtkMl_Context *ctx, GtkMl_Builder *b,
 GTKML_PUBLIC gboolean gtk_ml_build_getvar_imm(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err);
 // builds a push in the chosen basic_block
 GTKML_PUBLIC gboolean gtk_ml_build_assignvar_imm(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err);
+// builds a push in the chosen basic_block
+GTKML_PUBLIC gboolean gtk_ml_build_len(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err);
+// builds a push in the chosen basic_block
+GTKML_PUBLIC gboolean gtk_ml_build_array_index(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err);
+// builds a push in the chosen basic_block
+GTKML_PUBLIC gboolean gtk_ml_build_array_push(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err);
+// builds a push in the chosen basic_block
+GTKML_PUBLIC gboolean gtk_ml_build_array_pop(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err);
+// builds a push in the chosen basic_block
+GTKML_PUBLIC gboolean gtk_ml_build_map_get(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err);
+// builds a push in the chosen basic_block
+GTKML_PUBLIC gboolean gtk_ml_build_map_insert(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err);
+// builds a push in the chosen basic_block
+GTKML_PUBLIC gboolean gtk_ml_build_map_delete(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err);
+// builds a push in the chosen basic_block
+GTKML_PUBLIC gboolean gtk_ml_build_set_contains(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err);
+// builds a push in the chosen basic_block
+GTKML_PUBLIC gboolean gtk_ml_build_set_insert(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err);
+// builds a push in the chosen basic_block
+GTKML_PUBLIC gboolean gtk_ml_build_set_delete(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err);
 // builds a call to C in the chosen basic_block
 GTKML_PUBLIC gboolean gtk_ml_build_call_extended_std(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err, GtkMl_Static imm64);
 // builds a call to C in the chosen basic_block

--- a/include/gtk-ml.h
+++ b/include/gtk-ml.h
@@ -717,9 +717,9 @@ GTKML_PUBLIC GtkMl_S *gtk_ml_loadf(GtkMl_Context *ctx, char **src, GtkMl_S **err
 GTKML_PUBLIC GtkMl_S *gtk_ml_loads(GtkMl_Context *ctx, GtkMl_S **err, const char *src);
 
 // compile a lambda expression to bytecode
-GTKML_PUBLIC gboolean gtk_ml_compile_intrinsics(GtkMl_Builder *b, GtkMl_S **err, GtkMl_S *intrinsic);
+GTKML_PUBLIC gboolean gtk_ml_compile_intrinsics(GtkMl_Builder *b, GtkMl_BasicBlock **start, GtkMl_S **err, GtkMl_S *intrinsic);
 // compile a lambda expression to bytecode
-GTKML_PUBLIC gboolean gtk_ml_compile_macros(GtkMl_Builder *b, GtkMl_S **err, GtkMl_S *macro);
+GTKML_PUBLIC gboolean gtk_ml_compile_macros(GtkMl_Builder *b, GtkMl_BasicBlock **start, GtkMl_S **err, GtkMl_S *macro);
 // compile a lambda expression to bytecode
 GTKML_PUBLIC gboolean gtk_ml_compile(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S **err, GtkMl_S *lambda);
 // compile a lambda expression to bytecode with expanding macros

--- a/src/gtk-ml.c
+++ b/src/gtk-ml.c
@@ -5377,7 +5377,7 @@ GTKML_PRIVATE GtkMl_S *vm_std_emit_bytecode(GtkMl_Context *ctx, GtkMl_S **err, G
             *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
             return 0;
         }
-        return gtk_ml_build_branch_extended_absolute(arg_ctx, arg_b, *arg_basic_block, err, gtk_ml_append_static(arg_b, imm))? new_true(ctx, NULL) : NULL;
+        return gtk_ml_build_branch_absolute_extended(arg_ctx, arg_b, *arg_basic_block, err, gtk_ml_append_static(arg_b, imm))? new_true(ctx, NULL) : NULL;
     } else if (strlen(bc_ret) == bc_len && strncmp(bc_ptr, bc_ret, bc_len) == 0) {
         return gtk_ml_build_ret(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
     } else if (strlen(bc_add) == bc_len && strncmp(bc_ptr, bc_add, bc_len) == 0) {

--- a/src/gtk-ml.c
+++ b/src/gtk-ml.c
@@ -5247,6 +5247,11 @@ GTKML_PRIVATE GtkMl_S *vm_std_compile_expr(GtkMl_Context *ctx, GtkMl_S **err, Gt
 GTKML_PRIVATE GtkMl_S *vm_std_emit_bytecode(GtkMl_Context *ctx, GtkMl_S **err, GtkMl_S *expr) {
     (void) expr;
 
+    GtkMl_S *imm = 0;
+    if (expr->value.s_int.value == 6) {
+        imm = gtk_ml_pop(ctx);
+    }
+
     GtkMl_S *bc = gtk_ml_pop(ctx);
     unsigned int arg_cond = gtk_ml_pop(ctx)->value.s_int.value;
     GtkMl_BasicBlock **arg_basic_block = gtk_ml_pop(ctx)->value.s_lightdata.userdata;
@@ -5255,11 +5260,148 @@ GTKML_PRIVATE GtkMl_S *vm_std_emit_bytecode(GtkMl_Context *ctx, GtkMl_S **err, G
     const char *bc_ptr = bc->value.s_keyword.ptr;
     size_t bc_len = bc->value.s_keyword.len;
 
+    const char *bc_halt = "halt";
+    const char *bc_push_imm = "push-imm";
+    const char *bc_push_addr = "push-addr";
+    const char *bc_pop = "pop";
+    const char *bc_setf_imm = "setf-imm";
+    const char *bc_popf = "popf";
+    const char *bc_define = "define";
+    const char *bc_bind = "bind";
+    const char *bc_bind_args = "bind-args";
+    const char *bc_get_imm = "get-imm";
+    const char *bc_list_imm = "list-imm";
+    const char *bc_map_imm = "map-imm";
+    const char *bc_set_imm = "set-imm";
+    const char *bc_array_imm = "array-imm";
+    const char *bc_setmm_imm = "setmm-imm";
+    const char *bc_getmm_imm = "getmm-imm";
+    const char *bc_var_imm = "var-imm";
+    const char *bc_getvar_imm = "getvar-imm";
+    const char *bc_assignvar_imm = "assignvar-imm";
+    const char *bc_call_std = "call-std";
+    const char *bc_call = "call";
+    const char *bc_branch_absolute = "branch-absolute";
+    const char *bc_ret = "ret";
     const char *bc_add = "add";
+    const char *bc_sub = "sub";
+    const char *bc_mul = "mul";
+    const char *bc_div = "div";
+    const char *bc_mod = "mod";
+    const char *bc_bitand = "bitand";
+    const char *bc_bitor = "bitor";
+    const char *bc_bitxor = "bitxor";
+    const char *bc_cmp = "cmp";
 
-    if (strlen(bc_add) == bc_len && strncmp(bc_ptr, bc_add, bc_len) == 0) {
-        gtk_ml_builder_set_cond(arg_b, arg_cond);
+    gtk_ml_builder_set_cond(arg_b, arg_cond);
+    if (strlen(bc_halt) == bc_len && strncmp(bc_ptr, bc_halt, bc_len) == 0) {
+        return gtk_ml_build_halt(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_push_imm) == bc_len && strncmp(bc_ptr, bc_push_imm, bc_len) == 0) {
+        if (!imm) {
+            *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
+            return 0;
+        }
+        return gtk_ml_build_push_extended_imm(arg_ctx, arg_b, *arg_basic_block, err, gtk_ml_append_static(arg_b, imm))? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_push_addr) == bc_len && strncmp(bc_ptr, bc_push_addr, bc_len) == 0) {
+        if (!imm) {
+            *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
+            return 0;
+        }
+        return gtk_ml_build_push_extended_addr(arg_ctx, arg_b, *arg_basic_block, err, gtk_ml_append_static(arg_b, imm))? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_pop) == bc_len && strncmp(bc_ptr, bc_pop, bc_len) == 0) {
+        return gtk_ml_build_pop(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_setf_imm) == bc_len && strncmp(bc_ptr, bc_setf_imm, bc_len) == 0) {
+        if (!imm) {
+            *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
+            return 0;
+        }
+        return gtk_ml_build_setf_extended_imm(arg_ctx, arg_b, *arg_basic_block, err, gtk_ml_append_static(arg_b, imm))? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_popf) == bc_len && strncmp(bc_ptr, bc_popf, bc_len) == 0) {
+        return gtk_ml_build_popf(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_define) == bc_len && strncmp(bc_ptr, bc_define, bc_len) == 0) {
+        return gtk_ml_build_define(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_bind) == bc_len && strncmp(bc_ptr, bc_bind, bc_len) == 0) {
+        return gtk_ml_build_bind(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_bind_args) == bc_len && strncmp(bc_ptr, bc_bind_args, bc_len) == 0) {
+        return gtk_ml_build_bind_args(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_get_imm) == bc_len && strncmp(bc_ptr, bc_get_imm, bc_len) == 0) {
+        if (!imm) {
+            *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
+            return 0;
+        }
+        return gtk_ml_build_get_extended_imm(arg_ctx, arg_b, *arg_basic_block, err, gtk_ml_append_static(arg_b, imm))? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_list_imm) == bc_len && strncmp(bc_ptr, bc_list_imm, bc_len) == 0) {
+        if (!imm) {
+            *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
+            return 0;
+        }
+        return gtk_ml_build_list_extended_imm(arg_ctx, arg_b, *arg_basic_block, err, gtk_ml_append_static(arg_b, imm))? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_map_imm) == bc_len && strncmp(bc_ptr, bc_map_imm, bc_len) == 0) {
+        if (!imm) {
+            *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
+            return 0;
+        }
+        return gtk_ml_build_map_extended_imm(arg_ctx, arg_b, *arg_basic_block, err, gtk_ml_append_static(arg_b, imm))? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_set_imm) == bc_len && strncmp(bc_ptr, bc_set_imm, bc_len) == 0) {
+        if (!imm) {
+            *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
+            return 0;
+        }
+        return gtk_ml_build_set_extended_imm(arg_ctx, arg_b, *arg_basic_block, err, gtk_ml_append_static(arg_b, imm))? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_array_imm) == bc_len && strncmp(bc_ptr, bc_array_imm, bc_len) == 0) {
+        if (!imm) {
+            *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
+            return 0;
+        }
+        return gtk_ml_build_array_extended_imm(arg_ctx, arg_b, *arg_basic_block, err, gtk_ml_append_static(arg_b, imm))? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_setmm_imm) == bc_len && strncmp(bc_ptr, bc_setmm_imm, bc_len) == 0) {
+        return gtk_ml_build_setmm_imm(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_getmm_imm) == bc_len && strncmp(bc_ptr, bc_getmm_imm, bc_len) == 0) {
+        return gtk_ml_build_getmm_imm(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_var_imm) == bc_len && strncmp(bc_ptr, bc_var_imm, bc_len) == 0) {
+        return gtk_ml_build_var_imm(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_getvar_imm) == bc_len && strncmp(bc_ptr, bc_getvar_imm, bc_len) == 0) {
+        return gtk_ml_build_getvar_imm(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_assignvar_imm) == bc_len && strncmp(bc_ptr, bc_assignvar_imm, bc_len) == 0) {
+        return gtk_ml_build_assignvar_imm(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_call_std) == bc_len && strncmp(bc_ptr, bc_call_std, bc_len) == 0) {
+        if (!imm) {
+            *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
+            return 0;
+        }
+        return gtk_ml_build_call_extended_std(arg_ctx, arg_b, *arg_basic_block, err, gtk_ml_append_static(arg_b, imm))? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_call) == bc_len && strncmp(bc_ptr, bc_call, bc_len) == 0) {
+        return gtk_ml_build_call(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_branch_absolute) == bc_len && strncmp(bc_ptr, bc_branch_absolute, bc_len) == 0) {
+        if (!imm) {
+            *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
+            return 0;
+        }
+        return gtk_ml_build_branch_extended_absolute(arg_ctx, arg_b, *arg_basic_block, err, gtk_ml_append_static(arg_b, imm))? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_ret) == bc_len && strncmp(bc_ptr, bc_ret, bc_len) == 0) {
+        return gtk_ml_build_ret(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_add) == bc_len && strncmp(bc_ptr, bc_add, bc_len) == 0) {
         return gtk_ml_build_add(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_sub) == bc_len && strncmp(bc_ptr, bc_sub, bc_len) == 0) {
+        return gtk_ml_build_sub(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_mul) == bc_len && strncmp(bc_ptr, bc_mul, bc_len) == 0) {
+        return gtk_ml_build_mul(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_div) == bc_len && strncmp(bc_ptr, bc_div, bc_len) == 0) {
+        return gtk_ml_build_div(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_mod) == bc_len && strncmp(bc_ptr, bc_mod, bc_len) == 0) {
+        return gtk_ml_build_mod(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_bitand) == bc_len && strncmp(bc_ptr, bc_bitand, bc_len) == 0) {
+        return gtk_ml_build_bitand(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_bitor) == bc_len && strncmp(bc_ptr, bc_bitor, bc_len) == 0) {
+        return gtk_ml_build_bitor(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_bitxor) == bc_len && strncmp(bc_ptr, bc_bitxor, bc_len) == 0) {
+        return gtk_ml_build_bitxor(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_cmp) == bc_len && strncmp(bc_ptr, bc_cmp, bc_len) == 0) {
+        if (!imm) {
+            *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
+            return 0;
+        }
+        return gtk_ml_build_cmp(arg_ctx, arg_b, *arg_basic_block, err, gtk_ml_append_static(arg_b, imm))? new_true(ctx, NULL) : NULL;
     } else {
         *err = gtk_ml_error(ctx, "bytecode-error", GTKML_ERR_BYTECODE_ERROR, bc->span.ptr != NULL, bc->span.line, bc->span.col, 0);
         return NULL;

--- a/src/gtk-ml.c
+++ b/src/gtk-ml.c
@@ -2197,8 +2197,7 @@ GtkMl_S *gtk_ml_loads(GtkMl_Context *ctx, GtkMl_S **err, const char *src) {
     return result;
 }
 
-GTKML_PRIVATE gboolean compile_std_call(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, uint64_t function, GtkMl_S *args, gboolean compile_first);
-GTKML_PRIVATE gboolean compile_runtime_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt);
+GTKML_PRIVATE gboolean compile_std_call(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, uint64_t function, GtkMl_S *args, gboolean compile_first, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
 GTKML_PRIVATE gboolean compile_runtime_program(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, const char *linkage_name, GtkMl_S *stmt, gboolean ret);
 
 GTKML_PRIVATE gboolean compile_cond_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
@@ -2208,11 +2207,6 @@ GTKML_PRIVATE gboolean compile_body(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_
 GTKML_PRIVATE gboolean compile_program(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, const char *linkage_name, GtkMl_S *stmt, gboolean ret, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
 
 gboolean builder_application(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
-    (void) allow_intr;
-    (void) allow_macro;
-    (void) allow_runtime;
-    (void) allow_macro_expansion;
-
     GtkMl_S *args = gtk_ml_cdr(*stmt);
     if (args->kind == GTKML_S_NIL
             || gtk_ml_cdr(args)->kind == GTKML_S_NIL
@@ -2221,7 +2215,7 @@ gboolean builder_application(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBl
         return 0;
     }
 
-    return compile_std_call(ctx, b, basic_block, err, GTKML_STD_APPLICATION, *stmt, 0);
+    return compile_std_call(ctx, b, basic_block, err, GTKML_STD_APPLICATION, *stmt, 0, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
 }
 
 gboolean builder_new_window(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
@@ -2238,7 +2232,7 @@ gboolean builder_new_window(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlo
         return 0;
     }
 
-    return compile_std_call(ctx, b, basic_block, err, GTKML_STD_NEW_WINDOW, *stmt, 0);
+    return compile_std_call(ctx, b, basic_block, err, GTKML_STD_NEW_WINDOW, *stmt, 0, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
 }
 
 gboolean builder_setmetamap(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
@@ -2325,7 +2319,7 @@ gboolean builder_error(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **
         return 0;
     }
 
-    return compile_std_call(ctx, b, basic_block, err, GTKML_STD_ERROR, *stmt, 0);
+    return compile_std_call(ctx, b, basic_block, err, GTKML_STD_ERROR, *stmt, 0, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
 }
 
 gboolean builder_define(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
@@ -2426,7 +2420,7 @@ gboolean builder_compile_expr(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicB
         return 0;
     }
 
-    return compile_std_call(ctx, b, basic_block, err, GTKML_STD_COMPILE_EXPR, *stmt, 0);
+    return compile_std_call(ctx, b, basic_block, err, GTKML_STD_COMPILE_EXPR, *stmt, 0, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
 }
 
 gboolean builder_emit_bytecode(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
@@ -2447,7 +2441,7 @@ gboolean builder_emit_bytecode(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_Basic
         return 0;
     }
 
-    return compile_std_call(ctx, b, basic_block, err, GTKML_STD_EMIT_BYTECODE, *stmt, 0);
+    return compile_std_call(ctx, b, basic_block, err, GTKML_STD_EMIT_BYTECODE, *stmt, 0, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
 }
 
 gboolean builder_do(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
@@ -3231,7 +3225,7 @@ gboolean compile_cond_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_Bas
     }
 }
 
-gboolean compile_std_call(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, uint64_t function, GtkMl_S *args, gboolean compile_first) {
+gboolean compile_std_call(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, uint64_t function, GtkMl_S *args, gboolean compile_first, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     int64_t n = 0;
     if (!compile_first) {
         if (!gtk_ml_build_push_extended_imm(ctx, b, *basic_block, err, gtk_ml_append_static(b, gtk_ml_car(args)))) {
@@ -3241,7 +3235,7 @@ gboolean compile_std_call(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock
         ++n;
     }
     while (args->kind != GTKML_S_NIL) {
-        if (!compile_runtime_expression(ctx, b, basic_block, err, &gtk_ml_car(args))) {
+        if (!compile_expression(ctx, b, basic_block, err, &gtk_ml_car(args), allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
             return 0;
         }
         args = gtk_ml_cdr(args);
@@ -3348,10 +3342,6 @@ GTKML_PRIVATE GtkMl_VisitResult compile_array(GtkMl_Array *array, size_t idx, Gt
         return GTKML_VISIT_BREAK;
     }
     return GTKML_VISIT_RECURSE;
-}
-
-gboolean compile_runtime_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt) {
-    return compile_expression(ctx, b, basic_block, err, stmt, 0, 0, 1, 1);
 }
 
 gboolean compile_runtime_program(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, const char *linkage_name, GtkMl_S *lambda, gboolean ret) {
@@ -4718,17 +4708,18 @@ struct CollectData {
     gboolean change;
     GtkMl_Context *ctx;
     GtkMl_Builder *b;
+    gboolean *has_intr;
 };
 
-GTKML_PRIVATE gboolean collect_intrinsics_inner(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S *expr);
+GTKML_PRIVATE gboolean collect_intrinsics_inner(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S *expr, gboolean *has_intr);
 
 GTKML_PRIVATE GtkMl_VisitResult collect_intrinsics_map(GtkMl_HashTrie *ht, void *key, void *value, void *data) {
     (void) ht;
 
     struct CollectData *col = data;
 
-    col->change |= collect_intrinsics_inner(col->ctx, col->b, key);
-    col->change |= collect_intrinsics_inner(col->ctx, col->b, value);
+    col->change |= collect_intrinsics_inner(col->ctx, col->b, key, col->has_intr);
+    col->change |= collect_intrinsics_inner(col->ctx, col->b, value, col->has_intr);
 
     return GTKML_VISIT_RECURSE;
 }
@@ -4738,7 +4729,7 @@ GTKML_PRIVATE GtkMl_VisitResult collect_intrinsics_set(GtkMl_HashSet *hs, void *
 
     struct CollectData *col = data;
 
-    col->change |= collect_intrinsics_inner(col->ctx, col->b, key);
+    col->change |= collect_intrinsics_inner(col->ctx, col->b, key, col->has_intr);
 
     return GTKML_VISIT_RECURSE;
 }
@@ -4749,18 +4740,18 @@ GTKML_PRIVATE GtkMl_VisitResult collect_intrinsics_array(GtkMl_Array *array, siz
 
     struct CollectData *col = data;
 
-    col->change |= collect_intrinsics_inner(col->ctx, col->b, value);
+    col->change |= collect_intrinsics_inner(col->ctx, col->b, value, col->has_intr);
 
     return GTKML_VISIT_RECURSE;
 }
 
-gboolean collect_intrinsics_inner(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S *expr) {
+gboolean collect_intrinsics_inner(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S *expr, gboolean *has_intr) {
     switch (expr->kind) {
     case GTKML_S_LAMBDA: {
         gboolean change = 0;
         GtkMl_S *body = expr->value.s_lambda.body;
         while (body->kind != GTKML_S_NIL) {
-            change |= collect_intrinsics_inner(ctx, b, gtk_ml_car(body));
+            change |= collect_intrinsics_inner(ctx, b, gtk_ml_car(body), has_intr);
             body = gtk_ml_cdr(body);
         }
         return change;
@@ -4769,7 +4760,7 @@ gboolean collect_intrinsics_inner(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S 
         gboolean change = 0;
         GtkMl_S *body = expr->value.s_macro.body;
         while (body->kind != GTKML_S_NIL) {
-            change |= collect_intrinsics_inner(ctx, b, gtk_ml_car(body));
+            change |= collect_intrinsics_inner(ctx, b, gtk_ml_car(body), has_intr);
             body = gtk_ml_cdr(body);
         }
         return change;
@@ -4796,10 +4787,11 @@ gboolean collect_intrinsics_inner(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S 
                 gtk_ml_hash_set_insert(&new, &b->intr_fns, name);
                 gtk_ml_del_hash_set(ctx, &b->intr_fns, gtk_ml_delete_void_reference);
                 b->intr_fns = new;
+                *has_intr = 1;
                 change = 1;
 
                 while (body->kind != GTKML_S_NIL) {
-                    collect_intrinsics_inner(ctx, b, gtk_ml_car(body));
+                    collect_intrinsics_inner(ctx, b, gtk_ml_car(body), has_intr);
                     body = gtk_ml_cdr(body);
                 }
             } else if (fn->value.s_symbol.len == strlen(symbol_define_macro)
@@ -4813,7 +4805,7 @@ gboolean collect_intrinsics_inner(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S 
                 }
 
                 while (body->kind != GTKML_S_NIL) {
-                    change |= collect_intrinsics_inner(ctx, b, gtk_ml_car(body));
+                    change |= collect_intrinsics_inner(ctx, b, gtk_ml_car(body), has_intr);
                     body = gtk_ml_cdr(body);
                 }
 
@@ -4822,6 +4814,7 @@ gboolean collect_intrinsics_inner(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S 
                     gtk_ml_hash_set_insert(&new, &b->intr_fns, name);
                     gtk_ml_del_hash_set(ctx, &b->intr_fns, gtk_ml_delete_void_reference);
                     b->intr_fns = new;
+                    *has_intr = 1;
                 }
             } else if (fn->value.s_symbol.len == strlen(symbol_define)
                     && memcmp(fn->value.s_symbol.ptr, symbol_define, fn->value.s_symbol.len) == 0) {
@@ -4834,7 +4827,7 @@ gboolean collect_intrinsics_inner(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S 
                 }
 
                 while (body->kind != GTKML_S_NIL) {
-                    change |= collect_intrinsics_inner(ctx, b, gtk_ml_car(body));
+                    change |= collect_intrinsics_inner(ctx, b, gtk_ml_car(body), has_intr);
                     body = gtk_ml_cdr(body);
                 }
 
@@ -4843,58 +4836,60 @@ gboolean collect_intrinsics_inner(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S 
                     gtk_ml_hash_set_insert(&new, &b->intr_fns, name);
                     gtk_ml_del_hash_set(ctx, &b->intr_fns, gtk_ml_delete_void_reference);
                     b->intr_fns = new;
+                    *has_intr = 1;
                 }
             } else {
                 if (gtk_ml_hash_set_contains(&b->intr_fns, fn)) {
-                    return 1;
+                    return 0;
                 }
             }
         }
         return change;
     }
     case GTKML_S_ARRAY: {
-        struct CollectData col = { 0, ctx, b };
+        struct CollectData col = { 0, ctx, b, has_intr };
         gtk_ml_array_foreach(&expr->value.s_array.array, collect_intrinsics_array, &col);
         return col.change;
     }
     case GTKML_S_MAP: {
-        struct CollectData col = { 0, ctx, b };
+        struct CollectData col = { 0, ctx, b, has_intr };
         gtk_ml_hash_trie_foreach(&expr->value.s_map.map, collect_intrinsics_map, &col);
         return col.change;
     }
     case GTKML_S_SET: {
-        struct CollectData col = { 0, ctx, b };
+        struct CollectData col = { 0, ctx, b, has_intr };
         gtk_ml_hash_set_foreach(&expr->value.s_set.set, collect_intrinsics_set, &col);
         return col.change;
     }
     case GTKML_S_VAR:
-        return collect_intrinsics_inner(ctx, b, expr->value.s_var.expr);
+        return collect_intrinsics_inner(ctx, b, expr->value.s_var.expr, has_intr);
     case GTKML_S_VARARG:
-        return collect_intrinsics_inner(ctx, b, expr->value.s_vararg.expr);
+        return collect_intrinsics_inner(ctx, b, expr->value.s_vararg.expr, has_intr);
     case GTKML_S_QUOTE:
-        return collect_intrinsics_inner(ctx, b, expr->value.s_quote.expr);
+        return collect_intrinsics_inner(ctx, b, expr->value.s_quote.expr, has_intr);
     case GTKML_S_QUASIQUOTE:
-        return collect_intrinsics_inner(ctx, b, expr->value.s_quasiquote.expr);
+        return collect_intrinsics_inner(ctx, b, expr->value.s_quasiquote.expr, has_intr);
     case GTKML_S_UNQUOTE:
-        return collect_intrinsics_inner(ctx, b, expr->value.s_unquote.expr);
+        return collect_intrinsics_inner(ctx, b, expr->value.s_unquote.expr, has_intr);
     default:
         return 0;
     }
 }
 
 GTKML_PRIVATE void collect_intrinsics(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S *expr) {
-    while (collect_intrinsics_inner(ctx, b, expr)) {}
+    gboolean has_intr = 0;
+    while (collect_intrinsics_inner(ctx, b, expr, &has_intr)) {}
 }
 
-GTKML_PRIVATE gboolean collect_macros_inner(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S *expr);
+GTKML_PRIVATE gboolean collect_macros_inner(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S *expr, gboolean *has_macro);
 
 GTKML_PRIVATE GtkMl_VisitResult collect_macros_map(GtkMl_HashTrie *ht, void *key, void *value, void *data) {
     (void) ht;
 
     struct CollectData *col = data;
 
-    col->change |= collect_macros_inner(col->ctx, col->b, key);
-    col->change |= collect_macros_inner(col->ctx, col->b, value);
+    col->change |= collect_macros_inner(col->ctx, col->b, key, col->has_intr);
+    col->change |= collect_macros_inner(col->ctx, col->b, value, col->has_intr);
 
     return GTKML_VISIT_RECURSE;
 }
@@ -4904,7 +4899,7 @@ GTKML_PRIVATE GtkMl_VisitResult collect_macros_set(GtkMl_HashSet *hs, void *key,
 
     struct CollectData *col = data;
 
-    col->change |= collect_macros_inner(col->ctx, col->b, key);
+    col->change |= collect_macros_inner(col->ctx, col->b, key, col->has_intr);
 
     return GTKML_VISIT_RECURSE;
 }
@@ -4915,18 +4910,18 @@ GTKML_PRIVATE GtkMl_VisitResult collect_macros_array(GtkMl_Array *array, size_t 
 
     struct CollectData *col = data;
 
-    col->change |= collect_macros_inner(col->ctx, col->b, value);
+    col->change |= collect_macros_inner(col->ctx, col->b, value, col->has_intr);
 
     return GTKML_VISIT_RECURSE;
 }
 
-gboolean collect_macros_inner(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S *expr) {
+gboolean collect_macros_inner(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S *expr, gboolean *has_macro) {
     switch (expr->kind) {
     case GTKML_S_LAMBDA: {
         gboolean change = 0;
         GtkMl_S *body = expr->value.s_lambda.body;
         while (body->kind != GTKML_S_NIL) {
-            change |= collect_macros_inner(ctx, b, gtk_ml_car(body));
+            change |= collect_macros_inner(ctx, b, gtk_ml_car(body), has_macro);
             body = gtk_ml_cdr(body);
         }
         return change;
@@ -4935,7 +4930,7 @@ gboolean collect_macros_inner(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S *exp
         gboolean change = 0;
         GtkMl_S *body = expr->value.s_macro.body;
         while (body->kind != GTKML_S_NIL) {
-            change |= collect_macros_inner(ctx, b, gtk_ml_car(body));
+            change |= collect_macros_inner(ctx, b, gtk_ml_car(body), has_macro);
             body = gtk_ml_cdr(body);
         }
         return change;
@@ -4958,7 +4953,7 @@ gboolean collect_macros_inner(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S *exp
                 }
 
                 while (body->kind != GTKML_S_NIL) {
-                    change |= collect_macros_inner(ctx, b, gtk_ml_car(body));
+                    change |= collect_macros_inner(ctx, b, gtk_ml_car(body), has_macro);
                     body = gtk_ml_cdr(body);
                 }
 
@@ -4967,6 +4962,7 @@ gboolean collect_macros_inner(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S *exp
                     gtk_ml_hash_set_insert(&new, &b->macro_fns, name);
                     gtk_ml_del_hash_set(ctx, &b->macro_fns, gtk_ml_delete_void_reference);
                     b->macro_fns = new;
+                    *has_macro = 1;
                 }
             } else if (fn->value.s_symbol.len == strlen(symbol_define)
                     && memcmp(fn->value.s_symbol.ptr, symbol_define, fn->value.s_symbol.len) == 0) {
@@ -4979,7 +4975,7 @@ gboolean collect_macros_inner(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S *exp
                 }
 
                 while (body->kind != GTKML_S_NIL) {
-                    change |= collect_macros_inner(ctx, b, gtk_ml_car(body));
+                    change |= collect_macros_inner(ctx, b, gtk_ml_car(body), has_macro);
                     body = gtk_ml_cdr(body);
                 }
 
@@ -4988,47 +4984,49 @@ gboolean collect_macros_inner(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S *exp
                     gtk_ml_hash_set_insert(&new, &b->macro_fns, name);
                     gtk_ml_del_hash_set(ctx, &b->macro_fns, gtk_ml_delete_void_reference);
                     b->macro_fns = new;
+                    *has_macro = 1;
                 }
             } else {
                 if (gtk_ml_hash_set_contains(&b->macro_fns, fn)) {
-                    return 1;
+                    return 0;
                 }
             }
         }
         return change;
     }
     case GTKML_S_ARRAY: {
-        struct CollectData col = { 0, ctx, b };
+        struct CollectData col = { 0, ctx, b, has_macro };
         gtk_ml_array_foreach(&expr->value.s_array.array, collect_macros_array, &col);
         return col.change;
     }
     case GTKML_S_MAP: {
-        struct CollectData col = { 0, ctx, b };
+        struct CollectData col = { 0, ctx, b, has_macro };
         gtk_ml_hash_trie_foreach(&expr->value.s_map.map, collect_macros_map, &col);
         return col.change;
     }
     case GTKML_S_SET: {
-        struct CollectData col = { 0, ctx, b };
+        struct CollectData col = { 0, ctx, b, has_macro };
         gtk_ml_hash_set_foreach(&expr->value.s_set.set, collect_macros_set, &col);
         return col.change;
     }
     case GTKML_S_VAR:
-        return collect_macros_inner(ctx, b, expr->value.s_var.expr);
+        return collect_macros_inner(ctx, b, expr->value.s_var.expr, has_macro);
     case GTKML_S_VARARG:
-        return collect_macros_inner(ctx, b, expr->value.s_vararg.expr);
+        return collect_macros_inner(ctx, b, expr->value.s_vararg.expr, has_macro);
     case GTKML_S_QUOTE:
-        return collect_macros_inner(ctx, b, expr->value.s_quote.expr);
+        return collect_macros_inner(ctx, b, expr->value.s_quote.expr, has_macro);
     case GTKML_S_QUASIQUOTE:
-        return collect_macros_inner(ctx, b, expr->value.s_quasiquote.expr);
+        return collect_macros_inner(ctx, b, expr->value.s_quasiquote.expr, has_macro);
     case GTKML_S_UNQUOTE:
-        return collect_macros_inner(ctx, b, expr->value.s_unquote.expr);
+        return collect_macros_inner(ctx, b, expr->value.s_unquote.expr, has_macro);
     default:
         return 0;
     }
 }
 
 GTKML_PRIVATE void collect_macros(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S *expr) {
-    while (collect_macros_inner(ctx, b, expr)) {}
+    gboolean has_macro = 0;
+    while (collect_macros_inner(ctx, b, expr, &has_macro)) {}
 }
 
 gboolean gtk_ml_compile_intrinsics(GtkMl_Builder *b, GtkMl_BasicBlock **start, GtkMl_S **err, GtkMl_S *lambda) {
@@ -7338,11 +7336,17 @@ gboolean gtk_ml_ii_array_index(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction in
     (void) err;
     (void) instr;
 
-    GtkMl_S *index = gtk_ml_pop(vm->ctx);
     GtkMl_S *container = gtk_ml_pop(vm->ctx);
+    GtkMl_S *index = gtk_ml_pop(vm->ctx);
 
     if (index->kind != GTKML_S_INT) {
-        *err = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+        gtk_ml_dumpf(vm->ctx, stdout, NULL, index);
+        GtkMl_S *error = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+        GtkMl_S *new = new_map(vm->ctx, NULL, NULL);
+        gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
+        gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "expected", strlen("expected")), new_keyword(vm->ctx, NULL, 0, "int", strlen("int")));
+        error = new;
+        *err = error;
         return 0;
     }
 
@@ -7350,9 +7354,15 @@ gboolean gtk_ml_ii_array_index(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction in
     case GTKML_S_ARRAY:
         gtk_ml_push(vm->ctx, gtk_ml_array_get(&container->value.s_array.array, index->value.s_int.value));
         break;
-    default:
-        *err = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+    default: {
+        GtkMl_S *error = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+        GtkMl_S *new = new_map(vm->ctx, NULL, NULL);
+        gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
+        gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "expected", strlen("expected")), new_keyword(vm->ctx, NULL, 0, "array", strlen("array")));
+        error = new;
+        *err = error;
         return 0;
+    }
     }
 
     PC_INCREMENT;
@@ -7363,8 +7373,8 @@ gboolean gtk_ml_ii_array_push(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction ins
     (void) err;
     (void) instr;
 
-    GtkMl_S *value = gtk_ml_pop(vm->ctx);
     GtkMl_S *container = gtk_ml_pop(vm->ctx);
+    GtkMl_S *value = gtk_ml_pop(vm->ctx);
     GtkMl_S *result = new_array(vm->ctx, NULL);
     gtk_ml_del_array(vm->ctx, &result->value.s_array.array, gtk_ml_delete_value_reference);
 
@@ -7373,9 +7383,15 @@ gboolean gtk_ml_ii_array_push(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction ins
         gtk_ml_array_push(&result->value.s_array.array, &container->value.s_array.array, value);
         gtk_ml_push(vm->ctx, result);
         break;
-    default:
-        *err = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+    default: {
+        GtkMl_S *error = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+        GtkMl_S *new = new_map(vm->ctx, NULL, NULL);
+        gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
+        gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "expected", strlen("expected")), new_keyword(vm->ctx, NULL, 0, "array", strlen("array")));
+        error = new;
+        *err = error;
         return 0;
+    }
     }
 
     PC_INCREMENT;
@@ -7395,9 +7411,15 @@ gboolean gtk_ml_ii_array_pop(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction inst
         gtk_ml_array_pop(&result->value.s_array.array, &container->value.s_array.array);
         gtk_ml_push(vm->ctx, result);
         break;
-    default:
-        *err = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+    default: {
+        GtkMl_S *error = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+        GtkMl_S *new = new_map(vm->ctx, NULL, NULL);
+        gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
+        gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "expected", strlen("expected")), new_keyword(vm->ctx, NULL, 0, "array", strlen("array")));
+        error = new;
+        *err = error;
         return 0;
+    }
     }
 
     PC_INCREMENT;
@@ -7408,16 +7430,22 @@ gboolean gtk_ml_ii_map_get(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr)
     (void) err;
     (void) instr;
 
-    GtkMl_S *key = gtk_ml_pop(vm->ctx);
     GtkMl_S *container = gtk_ml_pop(vm->ctx);
+    GtkMl_S *key = gtk_ml_pop(vm->ctx);
 
     switch (container->kind) {
     case GTKML_S_MAP:
         gtk_ml_push(vm->ctx, gtk_ml_hash_trie_get(&container->value.s_map.map, key));
         break;
-    default:
-        *err = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+    default: {
+        GtkMl_S *error = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+        GtkMl_S *new = new_map(vm->ctx, NULL, NULL);
+        gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
+        gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "expected", strlen("expected")), new_keyword(vm->ctx, NULL, 0, "map", strlen("map")));
+        error = new;
+        *err = error;
         return 0;
+    }
     }
 
     PC_INCREMENT;
@@ -7428,9 +7456,9 @@ gboolean gtk_ml_ii_map_insert(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction ins
     (void) err;
     (void) instr;
 
-    GtkMl_S *value = gtk_ml_pop(vm->ctx);
-    GtkMl_S *key = gtk_ml_pop(vm->ctx);
     GtkMl_S *container = gtk_ml_pop(vm->ctx);
+    GtkMl_S *key = gtk_ml_pop(vm->ctx);
+    GtkMl_S *value = gtk_ml_pop(vm->ctx);
     GtkMl_S *result = new_map(vm->ctx, NULL, container->value.s_map.metamap);
     gtk_ml_del_hash_trie(vm->ctx, &result->value.s_map.map, gtk_ml_delete_void_reference);
 
@@ -7439,9 +7467,15 @@ gboolean gtk_ml_ii_map_insert(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction ins
         gtk_ml_hash_trie_insert(&result->value.s_map.map, &container->value.s_map.map, key, value);
         gtk_ml_push(vm->ctx, result);
         break;
-    default:
-        *err = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+    default: {
+        GtkMl_S *error = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+        GtkMl_S *new = new_map(vm->ctx, NULL, NULL);
+        gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
+        gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "expected", strlen("expected")), new_keyword(vm->ctx, NULL, 0, "map", strlen("map")));
+        error = new;
+        *err = error;
         return 0;
+    }
     }
 
     PC_INCREMENT;
@@ -7452,8 +7486,8 @@ gboolean gtk_ml_ii_map_delete(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction ins
     (void) err;
     (void) instr;
 
-    GtkMl_S *key = gtk_ml_pop(vm->ctx);
     GtkMl_S *container = gtk_ml_pop(vm->ctx);
+    GtkMl_S *key = gtk_ml_pop(vm->ctx);
     GtkMl_S *result = new_map(vm->ctx, NULL, container->value.s_map.metamap);
     gtk_ml_del_hash_trie(vm->ctx, &result->value.s_map.map, gtk_ml_delete_void_reference);
 
@@ -7462,9 +7496,15 @@ gboolean gtk_ml_ii_map_delete(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction ins
         gtk_ml_hash_trie_delete(&result->value.s_map.map, &container->value.s_map.map, key);
         gtk_ml_push(vm->ctx, result);
         break;
-    default:
-        *err = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+    default: {
+        GtkMl_S *error = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+        GtkMl_S *new = new_map(vm->ctx, NULL, NULL);
+        gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
+        gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "expected", strlen("expected")), new_keyword(vm->ctx, NULL, 0, "map", strlen("map")));
+        error = new;
+        *err = error;
         return 0;
+    }
     }
 
     PC_INCREMENT;
@@ -7475,16 +7515,22 @@ gboolean gtk_ml_ii_set_contains(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction i
     (void) err;
     (void) instr;
 
-    GtkMl_S *key = gtk_ml_pop(vm->ctx);
     GtkMl_S *container = gtk_ml_pop(vm->ctx);
+    GtkMl_S *key = gtk_ml_pop(vm->ctx);
 
     switch (container->kind) {
     case GTKML_S_SET:
         gtk_ml_push(vm->ctx, gtk_ml_hash_set_contains(&container->value.s_set.set, key)? new_true(vm->ctx, NULL) : new_false(vm->ctx, NULL));
         break;
-    default:
-        *err = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+    default: {
+        GtkMl_S *error = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+        GtkMl_S *new = new_map(vm->ctx, NULL, NULL);
+        gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
+        gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "expected", strlen("expected")), new_keyword(vm->ctx, NULL, 0, "set", strlen("set")));
+        error = new;
+        *err = error;
         return 0;
+    }
     }
 
     PC_INCREMENT;
@@ -7495,8 +7541,8 @@ gboolean gtk_ml_ii_set_insert(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction ins
     (void) err;
     (void) instr;
 
-    GtkMl_S *key = gtk_ml_pop(vm->ctx);
     GtkMl_S *container = gtk_ml_pop(vm->ctx);
+    GtkMl_S *key = gtk_ml_pop(vm->ctx);
     GtkMl_S *result = new_set(vm->ctx, NULL);
     gtk_ml_del_hash_set(vm->ctx, &result->value.s_set.set, gtk_ml_delete_void_reference);
 
@@ -7505,9 +7551,15 @@ gboolean gtk_ml_ii_set_insert(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction ins
         gtk_ml_hash_set_insert(&result->value.s_set.set, &container->value.s_set.set, key);
         gtk_ml_push(vm->ctx, result);
         break;
-    default:
-        *err = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+    default: {
+        GtkMl_S *error = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+        GtkMl_S *new = new_map(vm->ctx, NULL, NULL);
+        gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
+        gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "expected", strlen("expected")), new_keyword(vm->ctx, NULL, 0, "set", strlen("set")));
+        error = new;
+        *err = error;
         return 0;
+    }
     }
 
     PC_INCREMENT;
@@ -7518,8 +7570,8 @@ gboolean gtk_ml_ii_set_delete(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction ins
     (void) err;
     (void) instr;
 
-    GtkMl_S *key = gtk_ml_pop(vm->ctx);
     GtkMl_S *container = gtk_ml_pop(vm->ctx);
+    GtkMl_S *key = gtk_ml_pop(vm->ctx);
     GtkMl_S *result = new_set(vm->ctx, NULL);
     gtk_ml_del_hash_set(vm->ctx, &result->value.s_set.set, gtk_ml_delete_void_reference);
 
@@ -7528,9 +7580,15 @@ gboolean gtk_ml_ii_set_delete(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction ins
         gtk_ml_hash_set_delete(&result->value.s_set.set, &container->value.s_set.set, key);
         gtk_ml_push(vm->ctx, result);
         break;
-    default:
-        *err = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+    default: {
+        GtkMl_S *error = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+        GtkMl_S *new = new_map(vm->ctx, NULL, NULL);
+        gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
+        gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "expected", strlen("expected")), new_keyword(vm->ctx, NULL, 0, "set", strlen("set")));
+        error = new;
+        *err = error;
         return 0;
+    }
     }
 
     PC_INCREMENT;
@@ -7561,12 +7619,12 @@ gboolean gtk_ml_ibr_ret(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr) {
     (void) err;
     (void) instr;
 
-    gtk_ml_leave(vm->ctx);
-
     if (vm->reg[GTKML_R_FLAGS].flags & GTKML_F_TOPCALL) {
         vm->reg[GTKML_R_FLAGS].flags |= GTKML_F_HALT;
         PC_INCREMENT;
     } else {
+        gtk_ml_leave(vm->ctx);
+
         uint64_t pc = vm->call_stack[--vm->call_stack_ptr];
         uint64_t flags = vm->call_stack[--vm->call_stack_ptr];
         vm->reg[GTKML_R_PC].pc = pc;

--- a/src/gtk-ml.c
+++ b/src/gtk-ml.c
@@ -7362,10 +7362,17 @@ gboolean gtk_ml_ia_car(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr) {
     GtkMl_S *list = gtk_ml_pop(vm->ctx);
     if (list->kind != GTKML_S_LIST) {
         GtkMl_S *error = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+
         GtkMl_S *new = new_map(vm->ctx, NULL, NULL);
         gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
         gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "expected", strlen("expected")), new_keyword(vm->ctx, NULL, 0, "list", strlen("list")));
         error = new;
+
+        new = new_map(vm->ctx, NULL, NULL);
+        gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
+        gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "got-value", strlen("got-value")), list);
+        error = new;
+
         *err = error;
         return 0;
     }
@@ -7380,10 +7387,17 @@ gboolean gtk_ml_ia_cdr(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr) {
     GtkMl_S *list = gtk_ml_pop(vm->ctx);
     if (list->kind != GTKML_S_LIST) {
         GtkMl_S *error = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+
         GtkMl_S *new = new_map(vm->ctx, NULL, NULL);
         gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
         gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "expected", strlen("expected")), new_keyword(vm->ctx, NULL, 0, "list", strlen("list")));
         error = new;
+
+        new = new_map(vm->ctx, NULL, NULL);
+        gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
+        gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "got-value", strlen("got-value")), list);
+        error = new;
+
         *err = error;
         return 0;
     }
@@ -7707,10 +7721,17 @@ gboolean gtk_ml_ii_array_index(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction in
 
     if (index->kind != GTKML_S_INT) {
         GtkMl_S *error = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+
         GtkMl_S *new = new_map(vm->ctx, NULL, NULL);
         gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
         gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "expected", strlen("expected")), new_keyword(vm->ctx, NULL, 0, "int", strlen("int")));
         error = new;
+
+        new = new_map(vm->ctx, NULL, NULL);
+        gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
+        gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "got-value", strlen("got-value")), index);
+        error = new;
+
         *err = error;
         return 0;
     }
@@ -7721,10 +7742,17 @@ gboolean gtk_ml_ii_array_index(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction in
         break;
     default: {
         GtkMl_S *error = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+
         GtkMl_S *new = new_map(vm->ctx, NULL, NULL);
         gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
         gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "expected", strlen("expected")), new_keyword(vm->ctx, NULL, 0, "array", strlen("array")));
         error = new;
+
+        new = new_map(vm->ctx, NULL, NULL);
+        gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
+        gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "got-value", strlen("got-value")), container);
+        error = new;
+
         *err = error;
         return 0;
     }
@@ -7750,10 +7778,17 @@ gboolean gtk_ml_ii_array_push(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction ins
         break;
     default: {
         GtkMl_S *error = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+
         GtkMl_S *new = new_map(vm->ctx, NULL, NULL);
         gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
         gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "expected", strlen("expected")), new_keyword(vm->ctx, NULL, 0, "array", strlen("array")));
         error = new;
+
+        new = new_map(vm->ctx, NULL, NULL);
+        gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
+        gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "got-value", strlen("got-value")), container);
+        error = new;
+
         *err = error;
         return 0;
     }
@@ -7778,10 +7813,17 @@ gboolean gtk_ml_ii_array_pop(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction inst
         break;
     default: {
         GtkMl_S *error = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+
         GtkMl_S *new = new_map(vm->ctx, NULL, NULL);
         gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
         gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "expected", strlen("expected")), new_keyword(vm->ctx, NULL, 0, "array", strlen("array")));
         error = new;
+
+        new = new_map(vm->ctx, NULL, NULL);
+        gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
+        gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "got-value", strlen("got-value")), container);
+        error = new;
+
         *err = error;
         return 0;
     }
@@ -7804,10 +7846,17 @@ gboolean gtk_ml_ii_map_get(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr)
         break;
     default: {
         GtkMl_S *error = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+
         GtkMl_S *new = new_map(vm->ctx, NULL, NULL);
         gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
         gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "expected", strlen("expected")), new_keyword(vm->ctx, NULL, 0, "map", strlen("map")));
         error = new;
+
+        new = new_map(vm->ctx, NULL, NULL);
+        gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
+        gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "got-value", strlen("got-value")), container);
+        error = new;
+
         *err = error;
         return 0;
     }
@@ -7834,10 +7883,17 @@ gboolean gtk_ml_ii_map_insert(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction ins
         break;
     default: {
         GtkMl_S *error = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+
         GtkMl_S *new = new_map(vm->ctx, NULL, NULL);
         gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
         gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "expected", strlen("expected")), new_keyword(vm->ctx, NULL, 0, "map", strlen("map")));
         error = new;
+
+        new = new_map(vm->ctx, NULL, NULL);
+        gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
+        gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "got-value", strlen("got-value")), container);
+        error = new;
+
         *err = error;
         return 0;
     }
@@ -7863,10 +7919,17 @@ gboolean gtk_ml_ii_map_delete(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction ins
         break;
     default: {
         GtkMl_S *error = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+
         GtkMl_S *new = new_map(vm->ctx, NULL, NULL);
         gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
         gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "expected", strlen("expected")), new_keyword(vm->ctx, NULL, 0, "map", strlen("map")));
         error = new;
+
+        new = new_map(vm->ctx, NULL, NULL);
+        gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
+        gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "got-value", strlen("got-value")), container);
+        error = new;
+
         *err = error;
         return 0;
     }
@@ -7889,10 +7952,17 @@ gboolean gtk_ml_ii_set_contains(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction i
         break;
     default: {
         GtkMl_S *error = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+
         GtkMl_S *new = new_map(vm->ctx, NULL, NULL);
         gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
         gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "expected", strlen("expected")), new_keyword(vm->ctx, NULL, 0, "set", strlen("set")));
         error = new;
+
+        new = new_map(vm->ctx, NULL, NULL);
+        gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
+        gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "got-value", strlen("got-value")), container);
+        error = new;
+
         *err = error;
         return 0;
     }
@@ -7918,10 +7988,17 @@ gboolean gtk_ml_ii_set_insert(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction ins
         break;
     default: {
         GtkMl_S *error = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+
         GtkMl_S *new = new_map(vm->ctx, NULL, NULL);
         gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
         gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "expected", strlen("expected")), new_keyword(vm->ctx, NULL, 0, "set", strlen("set")));
         error = new;
+
+        new = new_map(vm->ctx, NULL, NULL);
+        gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
+        gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "got-value", strlen("got-value")), container);
+        error = new;
+
         *err = error;
         return 0;
     }
@@ -7947,10 +8024,17 @@ gboolean gtk_ml_ii_set_delete(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction ins
         break;
     default: {
         GtkMl_S *error = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+
         GtkMl_S *new = new_map(vm->ctx, NULL, NULL);
         gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
         gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "expected", strlen("expected")), new_keyword(vm->ctx, NULL, 0, "set", strlen("set")));
         error = new;
+
+        new = new_map(vm->ctx, NULL, NULL);
+        gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
+        gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "got-value", strlen("got-value")), container);
+        error = new;
+
         *err = error;
         return 0;
     }

--- a/src/gtk-ml.c
+++ b/src/gtk-ml.c
@@ -87,6 +87,9 @@ GTKML_PRIVATE gboolean builder_macro(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl
 GTKML_PRIVATE gboolean builder_cond(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
 GTKML_PRIVATE gboolean builder_while(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
 GTKML_PRIVATE gboolean builder_len(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_car(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_cdr(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_typeof(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
 GTKML_PRIVATE gboolean builder_index(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
 GTKML_PRIVATE gboolean builder_push(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
 GTKML_PRIVATE gboolean builder_pop(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
@@ -147,9 +150,14 @@ GTKML_PRIVATE gboolean gtk_ml_ia_bit_xor(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Inst
 GTKML_PRIVATE gboolean gtk_ml_ia_bit_nand(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
 GTKML_PRIVATE gboolean gtk_ml_ia_bit_nor(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
 GTKML_PRIVATE gboolean gtk_ml_ia_bit_xnor(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
+GTKML_PRIVATE gboolean gtk_ml_ia_car(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
+GTKML_PRIVATE gboolean gtk_ml_ia_cdr(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
 GTKML_PRIVATE gboolean gtk_ml_ia_bind(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
 GTKML_PRIVATE gboolean gtk_ml_ia_define(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
 GTKML_PRIVATE gboolean gtk_ml_ia_bind_args(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
+GTKML_PRIVATE gboolean gtk_ml_ia_enter(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
+GTKML_PRIVATE gboolean gtk_ml_ia_leave(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
+GTKML_PRIVATE gboolean gtk_ml_ia_typeof(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
 
 GTKML_PRIVATE gboolean gtk_ml_ii_push_imm(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
 GTKML_PRIVATE gboolean gtk_ml_ii_pop(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
@@ -224,9 +232,14 @@ GTKML_PRIVATE const char *S_I_ARITH[] = {
     [GTKML_IA_BIT_NAND] = GTKML_SIA_BIT_NAND,
     [GTKML_IA_BIT_NOR] = GTKML_SIA_BIT_NOR,
     [GTKML_IA_BIT_XNOR] = GTKML_SIA_BIT_XNOR,
+    [GTKML_IA_CAR] = GTKML_SIA_CAR,
+    [GTKML_IA_CDR] = GTKML_SIA_CDR,
     [GTKML_IA_BIND] = GTKML_SIA_BIND,
     [GTKML_IA_DEFINE] = GTKML_SIA_DEFINE,
     [GTKML_IA_BIND_ARGS] = GTKML_SIA_BIND_ARGS,
+    [GTKML_IA_TYPEOF] = GTKML_SIA_TYPEOF,
+    [GTKML_IA_ENTER] = GTKML_SIA_ENTER,
+    [GTKML_IA_LEAVE] = GTKML_SIA_LEAVE,
     [255] = NULL,
 };
 
@@ -349,6 +362,32 @@ GTKML_PRIVATE const char **S_CATEGORY[] = {
     [15] = NULL,
 };
 
+GTKML_PRIVATE const char *TYPENAME[] = {
+    [GTKML_S_NIL] = "nil",
+    [GTKML_S_FALSE] = "false",
+    [GTKML_S_TRUE] = "true",
+    [GTKML_S_INT] = "int",
+    [GTKML_S_FLOAT] = "float",
+    [GTKML_S_STRING] = "string",
+    [GTKML_S_SYMBOL] = "symbol",
+    [GTKML_S_KEYWORD] = "keyword",
+    [GTKML_S_LIST] = "list",
+    [GTKML_S_MAP] = "map",
+    [GTKML_S_SET] = "set",
+    [GTKML_S_ARRAY] = "array",
+    [GTKML_S_VAR] = "var",
+    [GTKML_S_VARARG] = "vararg",
+    [GTKML_S_QUOTE] = "quote",
+    [GTKML_S_QUASIQUOTE] = "quasiquote",
+    [GTKML_S_UNQUOTE] = "unquote",
+    [GTKML_S_LAMBDA] = "lambda",
+    [GTKML_S_PROGRAM] = "program",
+    [GTKML_S_ADDRESS] = "address",
+    [GTKML_S_MACRO] = "macro",
+    [GTKML_S_LIGHTDATA] = "lightdata",
+    [GTKML_S_USERDATA] = "userdata",
+};
+
 GTKML_PRIVATE gboolean (*CATEGORY[])(GtkMl_Vm *, GtkMl_S **, GtkMl_Instruction *) = {
     [0] = (gboolean (*)(GtkMl_Vm *, GtkMl_S **, GtkMl_Instruction *)) NULL,
     [GTKML_I_ARITH] = gtk_ml_ia,
@@ -385,9 +424,14 @@ GTKML_PRIVATE gboolean (*I_ARITH[])(GtkMl_Vm *, GtkMl_S **, GtkMl_Instruction) =
     [GTKML_IA_BIT_NAND] = gtk_ml_ia_bit_nand,
     [GTKML_IA_BIT_NOR] = gtk_ml_ia_bit_nor,
     [GTKML_IA_BIT_XNOR] = gtk_ml_ia_bit_xnor,
+    [GTKML_IA_CAR] = gtk_ml_ia_car,
+    [GTKML_IA_CDR] = gtk_ml_ia_cdr,
     [GTKML_IA_BIND] = gtk_ml_ia_bind,
     [GTKML_IA_DEFINE] = gtk_ml_ia_define,
     [GTKML_IA_BIND_ARGS] = gtk_ml_ia_bind_args,
+    [GTKML_IA_ENTER] = gtk_ml_ia_enter,
+    [GTKML_IA_LEAVE] = gtk_ml_ia_leave,
+    [GTKML_IA_TYPEOF] = gtk_ml_ia_typeof,
     [255] = (gboolean (*)(GtkMl_Vm *, GtkMl_S **, GtkMl_Instruction)) NULL,
 };
 
@@ -726,6 +770,33 @@ GtkMl_Builder *gtk_ml_new_builder() {
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
 
+    char *name_car = malloc(strlen("car") + 1);
+    strcpy(name_car, "car");
+    b->builders[b->len_builder].name = name_car;
+    b->builders[b->len_builder].fn = builder_car;
+    b->builders[b->len_builder].require_intrinsic = 0;
+    b->builders[b->len_builder].require_macro = 0;
+    b->builders[b->len_builder].require_runtime = 0;
+    ++b->len_builder;
+
+    char *name_cdr = malloc(strlen("cdr") + 1);
+    strcpy(name_cdr, "cdr");
+    b->builders[b->len_builder].name = name_cdr;
+    b->builders[b->len_builder].fn = builder_cdr;
+    b->builders[b->len_builder].require_intrinsic = 0;
+    b->builders[b->len_builder].require_macro = 0;
+    b->builders[b->len_builder].require_runtime = 0;
+    ++b->len_builder;
+
+    char *name_typeof = malloc(strlen("typeof") + 1);
+    strcpy(name_typeof, "typeof");
+    b->builders[b->len_builder].name = name_typeof;
+    b->builders[b->len_builder].fn = builder_typeof;
+    b->builders[b->len_builder].require_intrinsic = 0;
+    b->builders[b->len_builder].require_macro = 0;
+    b->builders[b->len_builder].require_runtime = 0;
+    ++b->len_builder;
+
     char *name_index = malloc(strlen("index") + 1);
     strcpy(name_index, "index");
     b->builders[b->len_builder].name = name_index;
@@ -1024,16 +1095,20 @@ gboolean build(GtkMl_Context *ctx, GtkMl_Program *out, GtkMl_S **err, GtkMl_Buil
 
     for (size_t i = 0; i < n;) {
         GtkMl_Instruction instr = result[i];
-        if (instr.gen.category != GTKML_EI_EXPORT && (instr.gen.category & GTKML_EI_IMM_EXTERN)) {
+        if (instr.gen.category != GTKML_EI_EXPORT && (instr.gen.category & GTKML_I_IMM_EXTERN)) {
             GtkMl_S *ext;
             if (instr.gen.category & GTKML_I_EXTENDED) {
                 ext = statics[result[i + 1].imm64];
-            } else if ((instr.gen.category & ~GTKML_EI_IMM_EXTERN) == GTKML_I_IMM) {
+            } else if (instr.gen.category == (GTKML_I_IMM | GTKML_I_IMM_EXTERN)) {
                 ext = statics[instr.imm.imm];
-            } else if ((instr.gen.category & ~GTKML_EI_BR_EXTERN) == GTKML_I_BR) {
+            } else if (instr.gen.category == (GTKML_I_BR | GTKML_I_BR_EXTERN)) {
                 ext = statics[instr.br.imm];
             } else {
                 *err = gtk_ml_error(ctx, "category-error", GTKML_ERR_CATEGORY_ERROR, 0, 0, 0, 0);
+                return 0;
+            }
+            if (ext->kind != GTKML_S_STRING) {
+                *err = gtk_ml_error(ctx, "linkage-error", GTKML_ERR_LINKAGE_ERROR, 0, 0, 0, 0);
                 return 0;
             }
             const char *bb1 = ext->value.s_string.ptr;
@@ -1140,6 +1215,15 @@ gboolean build(GtkMl_Context *ctx, GtkMl_Program *out, GtkMl_S **err, GtkMl_Buil
         *prev = macro_values;
         // then it's safe to delete the macro context and vm
         gtk_ml_del_context(b->macro_ctx);
+
+        // and the values from the intr context into the real context
+        GtkMl_S *intr_values = b->intr_ctx->first;
+        b->intr_ctx->first = NULL;
+        prev = &ctx->first;
+        while (*prev) {
+            prev = &(*prev)->next;
+        }
+        *prev = intr_values;
         // and the intr context
         gtk_ml_del_context(b->intr_ctx);
 
@@ -2807,6 +2891,54 @@ gboolean builder_len(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **ba
     return gtk_ml_build_len(ctx, b, *basic_block, err);
 }
 
+gboolean builder_car(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+    GtkMl_S *args = gtk_ml_cdr(*stmt);
+
+    if (args->kind == GTKML_S_NIL) {
+        *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, (*stmt)->span.ptr != NULL, (*stmt)->span.line, (*stmt)->span.col, 0);
+        return 0;
+    }
+
+    GtkMl_S **list = &gtk_ml_car(args);
+
+    if (!compile_expression(ctx, b, basic_block, err, list, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
+        return 0;
+    }
+    return gtk_ml_build_car(ctx, b, *basic_block, err);
+}
+
+gboolean builder_cdr(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+    GtkMl_S *args = gtk_ml_cdr(*stmt);
+
+    if (args->kind == GTKML_S_NIL) {
+        *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, (*stmt)->span.ptr != NULL, (*stmt)->span.line, (*stmt)->span.col, 0);
+        return 0;
+    }
+
+    GtkMl_S **list = &gtk_ml_car(args);
+
+    if (!compile_expression(ctx, b, basic_block, err, list, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
+        return 0;
+    }
+    return gtk_ml_build_cdr(ctx, b, *basic_block, err);
+}
+
+gboolean builder_typeof(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+    GtkMl_S *args = gtk_ml_cdr(*stmt);
+
+    if (args->kind == GTKML_S_NIL) {
+        *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, (*stmt)->span.ptr != NULL, (*stmt)->span.line, (*stmt)->span.col, 0);
+        return 0;
+    }
+
+    GtkMl_S **value = &gtk_ml_car(args);
+
+    if (!compile_expression(ctx, b, basic_block, err, value, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
+        return 0;
+    }
+    return gtk_ml_build_typeof(ctx, b, *basic_block, err);
+}
+
 gboolean builder_index(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
@@ -3870,6 +4002,42 @@ gboolean gtk_ml_build_define(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBl
     return 1;
 }
 
+gboolean gtk_ml_build_car(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err) {
+    (void) ctx;
+    (void) err;
+
+    if (basic_block->len_exec == basic_block->cap_exec) {
+        basic_block->cap_exec *= 2;
+        basic_block->exec = realloc(basic_block->exec, sizeof(GtkMl_Instruction) * basic_block->cap_exec);
+    }
+
+    basic_block->exec[basic_block->len_exec].instr = 0;
+    basic_block->exec[basic_block->len_exec].arith.cond = gtk_ml_builder_clear_cond(b);
+    basic_block->exec[basic_block->len_exec].arith.category = GTKML_I_ARITH;
+    basic_block->exec[basic_block->len_exec].arith.opcode = GTKML_IA_CAR;
+    ++basic_block->len_exec;
+
+    return 1;
+}
+
+gboolean gtk_ml_build_cdr(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err) {
+    (void) ctx;
+    (void) err;
+
+    if (basic_block->len_exec == basic_block->cap_exec) {
+        basic_block->cap_exec *= 2;
+        basic_block->exec = realloc(basic_block->exec, sizeof(GtkMl_Instruction) * basic_block->cap_exec);
+    }
+
+    basic_block->exec[basic_block->len_exec].instr = 0;
+    basic_block->exec[basic_block->len_exec].arith.cond = gtk_ml_builder_clear_cond(b);
+    basic_block->exec[basic_block->len_exec].arith.category = GTKML_I_ARITH;
+    basic_block->exec[basic_block->len_exec].arith.opcode = GTKML_IA_CDR;
+    ++basic_block->len_exec;
+
+    return 1;
+}
+
 gboolean gtk_ml_build_bind(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err) {
     (void) ctx;
     (void) err;
@@ -3901,6 +4069,60 @@ gboolean gtk_ml_build_bind_args(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_Basi
     basic_block->exec[basic_block->len_exec].arith.cond = gtk_ml_builder_clear_cond(b);
     basic_block->exec[basic_block->len_exec].arith.category = GTKML_I_ARITH;
     basic_block->exec[basic_block->len_exec].arith.opcode = GTKML_IA_BIND_ARGS;
+    ++basic_block->len_exec;
+
+    return 1;
+}
+
+gboolean gtk_ml_build_enter(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err) {
+    (void) ctx;
+    (void) err;
+
+    if (basic_block->len_exec == basic_block->cap_exec) {
+        basic_block->cap_exec *= 2;
+        basic_block->exec = realloc(basic_block->exec, sizeof(GtkMl_Instruction) * basic_block->cap_exec);
+    }
+
+    basic_block->exec[basic_block->len_exec].instr = 0;
+    basic_block->exec[basic_block->len_exec].arith.cond = gtk_ml_builder_clear_cond(b);
+    basic_block->exec[basic_block->len_exec].arith.category = GTKML_I_ARITH;
+    basic_block->exec[basic_block->len_exec].arith.opcode = GTKML_IA_ENTER;
+    ++basic_block->len_exec;
+
+    return 1;
+}
+
+gboolean gtk_ml_build_leave(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err) {
+    (void) ctx;
+    (void) err;
+
+    if (basic_block->len_exec == basic_block->cap_exec) {
+        basic_block->cap_exec *= 2;
+        basic_block->exec = realloc(basic_block->exec, sizeof(GtkMl_Instruction) * basic_block->cap_exec);
+    }
+
+    basic_block->exec[basic_block->len_exec].instr = 0;
+    basic_block->exec[basic_block->len_exec].arith.cond = gtk_ml_builder_clear_cond(b);
+    basic_block->exec[basic_block->len_exec].arith.category = GTKML_I_ARITH;
+    basic_block->exec[basic_block->len_exec].arith.opcode = GTKML_IA_LEAVE;
+    ++basic_block->len_exec;
+
+    return 1;
+}
+
+gboolean gtk_ml_build_typeof(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err) {
+    (void) ctx;
+    (void) err;
+
+    if (basic_block->len_exec == basic_block->cap_exec) {
+        basic_block->cap_exec *= 2;
+        basic_block->exec = realloc(basic_block->exec, sizeof(GtkMl_Instruction) * basic_block->cap_exec);
+    }
+
+    basic_block->exec[basic_block->len_exec].instr = 0;
+    basic_block->exec[basic_block->len_exec].arith.cond = gtk_ml_builder_clear_cond(b);
+    basic_block->exec[basic_block->len_exec].arith.category = GTKML_I_ARITH;
+    basic_block->exec[basic_block->len_exec].arith.opcode = GTKML_IA_TYPEOF;
     ++basic_block->len_exec;
 
     return 1;
@@ -6089,8 +6311,13 @@ GTKML_PRIVATE GtkMl_S *vm_std_emit_bytecode(GtkMl_Context *ctx, GtkMl_S **err, G
     const char *bc_setf_imm = "setf-imm";
     const char *bc_popf = "popf";
     const char *bc_define = "define";
+    const char *bc_car = "car";
+    const char *bc_cdr = "cdr";
     const char *bc_bind = "bind";
     const char *bc_bind_args = "bind-args";
+    const char *bc_enter = "enter";
+    const char *bc_leave = "leave";
+    const char *bc_typeof = "typeof";
     const char *bc_get_imm = "get-imm";
     const char *bc_list_imm = "list-imm";
     const char *bc_map_imm = "map-imm";
@@ -6152,10 +6379,20 @@ GTKML_PRIVATE GtkMl_S *vm_std_emit_bytecode(GtkMl_Context *ctx, GtkMl_S **err, G
         return gtk_ml_build_popf(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
     } else if (strlen(bc_define) == bc_len && strncmp(bc_ptr, bc_define, bc_len) == 0) {
         return gtk_ml_build_define(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_car) == bc_len && strncmp(bc_ptr, bc_car, bc_len) == 0) {
+        return gtk_ml_build_car(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_cdr) == bc_len && strncmp(bc_ptr, bc_cdr, bc_len) == 0) {
+        return gtk_ml_build_cdr(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
     } else if (strlen(bc_bind) == bc_len && strncmp(bc_ptr, bc_bind, bc_len) == 0) {
         return gtk_ml_build_bind(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
     } else if (strlen(bc_bind_args) == bc_len && strncmp(bc_ptr, bc_bind_args, bc_len) == 0) {
         return gtk_ml_build_bind_args(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_enter) == bc_len && strncmp(bc_ptr, bc_enter, bc_len) == 0) {
+        return gtk_ml_build_enter(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_leave) == bc_len && strncmp(bc_ptr, bc_leave, bc_len) == 0) {
+        return gtk_ml_build_leave(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_typeof) == bc_len && strncmp(bc_ptr, bc_typeof, bc_len) == 0) {
+        return gtk_ml_build_typeof(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
     } else if (strlen(bc_get_imm) == bc_len && strncmp(bc_ptr, bc_get_imm, bc_len) == 0) {
         if (!imm) {
             *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
@@ -7051,12 +7288,73 @@ gboolean gtk_ml_ia_bit_xnor(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr
     return 1;
 }
 
+gboolean gtk_ml_ia_car(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr) {
+    (void) err;
+    (void) instr;
+    GtkMl_S *list = gtk_ml_pop(vm->ctx);
+    if (list->kind != GTKML_S_LIST) {
+        GtkMl_S *error = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+        GtkMl_S *new = new_map(vm->ctx, NULL, NULL);
+        gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
+        gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "expected", strlen("expected")), new_keyword(vm->ctx, NULL, 0, "list", strlen("list")));
+        error = new;
+        *err = error;
+        return 0;
+    }
+    gtk_ml_push(vm->ctx, gtk_ml_car(list));
+    PC_INCREMENT;
+    return 1;
+}
+
+gboolean gtk_ml_ia_cdr(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr) {
+    (void) err;
+    (void) instr;
+    GtkMl_S *list = gtk_ml_pop(vm->ctx);
+    if (list->kind != GTKML_S_LIST) {
+        GtkMl_S *error = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+        GtkMl_S *new = new_map(vm->ctx, NULL, NULL);
+        gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);
+        gtk_ml_hash_trie_insert(&new->value.s_map.map, &error->value.s_map.map, new_keyword(vm->ctx, NULL, 0, "expected", strlen("expected")), new_keyword(vm->ctx, NULL, 0, "list", strlen("list")));
+        error = new;
+        *err = error;
+        return 0;
+    }
+    gtk_ml_push(vm->ctx, gtk_ml_cdr(list));
+    PC_INCREMENT;
+    return 1;
+}
+
 gboolean gtk_ml_ia_bind(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr) {
     (void) err;
     (void) instr;
     GtkMl_S *key = gtk_ml_pop(vm->ctx);
     GtkMl_S *value = gtk_ml_pop(vm->ctx);
     gtk_ml_bind(vm->ctx, key, value);
+    PC_INCREMENT;
+    return 1;
+}
+
+gboolean gtk_ml_ia_enter(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr) {
+    (void) err;
+    (void) instr;
+    gtk_ml_enter(vm->ctx);
+    PC_INCREMENT;
+    return 1;
+}
+
+gboolean gtk_ml_ia_leave(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr) {
+    (void) err;
+    (void) instr;
+    gtk_ml_leave(vm->ctx);
+    PC_INCREMENT;
+    return 1;
+}
+
+gboolean gtk_ml_ia_typeof(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr) {
+    (void) err;
+    (void) instr;
+    GtkMl_S *value = gtk_ml_pop(vm->ctx);
+    gtk_ml_push(vm->ctx, new_keyword(vm->ctx, NULL, 0, TYPENAME[value->kind], strlen(TYPENAME[value->kind])));
     PC_INCREMENT;
     return 1;
 }
@@ -7340,7 +7638,6 @@ gboolean gtk_ml_ii_array_index(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction in
     GtkMl_S *index = gtk_ml_pop(vm->ctx);
 
     if (index->kind != GTKML_S_INT) {
-        gtk_ml_dumpf(vm->ctx, stdout, NULL, index);
         GtkMl_S *error = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
         GtkMl_S *new = new_map(vm->ctx, NULL, NULL);
         gtk_ml_del_hash_trie(vm->ctx, &new->value.s_map.map, gtk_ml_delete_void_reference);

--- a/src/gtk-ml.c
+++ b/src/gtk-ml.c
@@ -86,6 +86,10 @@ GTKML_PRIVATE gboolean builder_lambda(GtkMl_Context *ctx, GtkMl_Builder *b, GtkM
 GTKML_PRIVATE gboolean builder_macro(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
 GTKML_PRIVATE gboolean builder_cond(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
 GTKML_PRIVATE gboolean builder_while(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_len(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_index(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_push(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_pop(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
 GTKML_PRIVATE gboolean builder_add(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
 GTKML_PRIVATE gboolean builder_sub(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
 GTKML_PRIVATE gboolean builder_mul(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
@@ -161,6 +165,16 @@ GTKML_PRIVATE gboolean gtk_ml_ii_getmm_imm(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_In
 GTKML_PRIVATE gboolean gtk_ml_ii_var_imm(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
 GTKML_PRIVATE gboolean gtk_ml_ii_getvar_imm(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
 GTKML_PRIVATE gboolean gtk_ml_ii_assignvar_imm(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
+GTKML_PRIVATE gboolean gtk_ml_ii_len(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
+GTKML_PRIVATE gboolean gtk_ml_ii_array_index(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
+GTKML_PRIVATE gboolean gtk_ml_ii_array_push(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
+GTKML_PRIVATE gboolean gtk_ml_ii_array_pop(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
+GTKML_PRIVATE gboolean gtk_ml_ii_map_get(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
+GTKML_PRIVATE gboolean gtk_ml_ii_map_insert(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
+GTKML_PRIVATE gboolean gtk_ml_ii_map_delete(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
+GTKML_PRIVATE gboolean gtk_ml_ii_set_contains(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
+GTKML_PRIVATE gboolean gtk_ml_ii_set_insert(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
+GTKML_PRIVATE gboolean gtk_ml_ii_set_delete(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
 
 GTKML_PRIVATE gboolean gtk_ml_ibr_call(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
 GTKML_PRIVATE gboolean gtk_ml_ibr_ret(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr);
@@ -231,6 +245,16 @@ GTKML_PRIVATE const char *S_I_IMM[] = {
     [GTKML_II_VAR_IMM] = GTKML_SII_VAR_IMM,
     [GTKML_II_GETVAR_IMM] = GTKML_SII_GETVAR_IMM,
     [GTKML_II_ASSIGNVAR_IMM] = GTKML_SII_ASSIGNVAR_IMM,
+    [GTKML_II_LEN] = GTKML_SII_LEN,
+    [GTKML_II_ARRAY_INDEX] = GTKML_SII_ARRAY_INDEX,
+    [GTKML_II_ARRAY_PUSH] = GTKML_SII_ARRAY_PUSH,
+    [GTKML_II_ARRAY_POP] = GTKML_SII_ARRAY_POP,
+    [GTKML_II_MAP_GET] = GTKML_SII_MAP_GET,
+    [GTKML_II_MAP_INSERT] = GTKML_SII_MAP_INSERT,
+    [GTKML_II_MAP_DELETE] = GTKML_SII_MAP_DELETE,
+    [GTKML_II_SET_CONTAINS] = GTKML_SII_SET_CONTAINS,
+    [GTKML_II_SET_INSERT] = GTKML_SII_SET_INSERT,
+    [GTKML_II_SET_DELETE] = GTKML_SII_SET_DELETE,
     [255] = NULL,
 };
 
@@ -249,6 +273,16 @@ GTKML_PRIVATE const char *S_I_IMM_EXTERN[] = {
     [GTKML_II_VAR_IMM] = GTKML_SII_VAR_IMM,
     [GTKML_II_GETVAR_IMM] = GTKML_SII_GETVAR_IMM,
     [GTKML_II_ASSIGNVAR_IMM] = GTKML_SII_ASSIGNVAR_IMM,
+    [GTKML_II_LEN] = GTKML_SII_LEN,
+    [GTKML_II_ARRAY_INDEX] = GTKML_SII_ARRAY_INDEX,
+    [GTKML_II_ARRAY_PUSH] = GTKML_SII_ARRAY_PUSH,
+    [GTKML_II_ARRAY_POP] = GTKML_SII_ARRAY_POP,
+    [GTKML_II_MAP_GET] = GTKML_SII_MAP_GET,
+    [GTKML_II_MAP_INSERT] = GTKML_SII_MAP_INSERT,
+    [GTKML_II_MAP_DELETE] = GTKML_SII_MAP_DELETE,
+    [GTKML_II_SET_CONTAINS] = GTKML_SII_SET_CONTAINS,
+    [GTKML_II_SET_INSERT] = GTKML_SII_SET_INSERT,
+    [GTKML_II_SET_DELETE] = GTKML_SII_SET_DELETE,
     [255] = NULL,
 };
 
@@ -372,6 +406,16 @@ GTKML_PRIVATE gboolean (*I_IMM[])(GtkMl_Vm *, GtkMl_S **, GtkMl_Instruction) = {
     [GTKML_II_VAR_IMM] = gtk_ml_ii_var_imm,
     [GTKML_II_GETVAR_IMM] = gtk_ml_ii_getvar_imm,
     [GTKML_II_ASSIGNVAR_IMM] = gtk_ml_ii_assignvar_imm,
+    [GTKML_II_LEN] = gtk_ml_ii_len,
+    [GTKML_II_ARRAY_INDEX] = gtk_ml_ii_array_index,
+    [GTKML_II_ARRAY_PUSH] = gtk_ml_ii_array_push,
+    [GTKML_II_ARRAY_POP] = gtk_ml_ii_array_pop,
+    [GTKML_II_MAP_GET] = gtk_ml_ii_map_get,
+    [GTKML_II_MAP_INSERT] = gtk_ml_ii_map_insert,
+    [GTKML_II_MAP_DELETE] = gtk_ml_ii_map_delete,
+    [GTKML_II_SET_CONTAINS] = gtk_ml_ii_set_contains,
+    [GTKML_II_SET_INSERT] = gtk_ml_ii_set_insert,
+    [GTKML_II_SET_DELETE] = gtk_ml_ii_set_delete,
     [255] = (gboolean (*)(GtkMl_Vm *, GtkMl_S **, GtkMl_Instruction)) NULL,
 };
 
@@ -668,6 +712,42 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_while, "while");
     b->builders[b->len_builder].name = name_while;
     b->builders[b->len_builder].fn = builder_while;
+    b->builders[b->len_builder].require_intrinsic = 0;
+    b->builders[b->len_builder].require_macro = 0;
+    b->builders[b->len_builder].require_runtime = 0;
+    ++b->len_builder;
+
+    char *name_len = malloc(strlen("len") + 1);
+    strcpy(name_len, "len");
+    b->builders[b->len_builder].name = name_len;
+    b->builders[b->len_builder].fn = builder_len;
+    b->builders[b->len_builder].require_intrinsic = 0;
+    b->builders[b->len_builder].require_macro = 0;
+    b->builders[b->len_builder].require_runtime = 0;
+    ++b->len_builder;
+
+    char *name_index = malloc(strlen("index") + 1);
+    strcpy(name_index, "index");
+    b->builders[b->len_builder].name = name_index;
+    b->builders[b->len_builder].fn = builder_index;
+    b->builders[b->len_builder].require_intrinsic = 0;
+    b->builders[b->len_builder].require_macro = 0;
+    b->builders[b->len_builder].require_runtime = 0;
+    ++b->len_builder;
+
+    char *name_push = malloc(strlen("push") + 1);
+    strcpy(name_push, "push");
+    b->builders[b->len_builder].name = name_push;
+    b->builders[b->len_builder].fn = builder_push;
+    b->builders[b->len_builder].require_intrinsic = 0;
+    b->builders[b->len_builder].require_macro = 0;
+    b->builders[b->len_builder].require_runtime = 0;
+    ++b->len_builder;
+
+    char *name_pop = malloc(strlen("pop") + 1);
+    strcpy(name_pop, "pop");
+    b->builders[b->len_builder].name = name_pop;
+    b->builders[b->len_builder].fn = builder_pop;
     b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
@@ -1362,6 +1442,7 @@ GTKML_PRIVATE gboolean lex(GtkMl_Context *ctx, GtkMl_Token **tokenv, size_t *tok
             int64_t intval = strtoll(src, &endptr, 10);
             if (*endptr == ' ' || *endptr == '\n' || *endptr == '\t'
                     || *endptr == '(' || *endptr == ')'
+                    || *endptr == '[' || *endptr == ']'
                     || *endptr == '{' || *endptr == '}') {
                 (*tokenv)[*tokenc].kind = GTKML_TOK_INT;
                 (*tokenv)[*tokenc].value.intval = intval;
@@ -2714,6 +2795,78 @@ gboolean builder_while(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **
     *basic_block = end;
 
     return 1;
+}
+
+gboolean builder_len(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+    GtkMl_S *args = gtk_ml_cdr(*stmt);
+
+    if (args->kind == GTKML_S_NIL) {
+        *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, (*stmt)->span.ptr != NULL, (*stmt)->span.line, (*stmt)->span.col, 0);
+        return 0;
+    }
+
+    GtkMl_S **container = &gtk_ml_car(args);
+
+    if (!compile_expression(ctx, b, basic_block, err, container, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
+        return 0;
+    }
+    return gtk_ml_build_len(ctx, b, *basic_block, err);
+}
+
+gboolean builder_index(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+    GtkMl_S *args = gtk_ml_cdr(*stmt);
+
+    if (args->kind == GTKML_S_NIL && gtk_ml_cdr(args)->kind == GTKML_S_NIL) {
+        *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, (*stmt)->span.ptr != NULL, (*stmt)->span.line, (*stmt)->span.col, 0);
+        return 0;
+    }
+
+    GtkMl_S **array = &gtk_ml_car(args);
+    GtkMl_S **index = &gtk_ml_cdar(args);
+
+    if (!compile_expression(ctx, b, basic_block, err, index, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
+        return 0;
+    }
+    if (!compile_expression(ctx, b, basic_block, err, array, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
+        return 0;
+    }
+    return gtk_ml_build_array_index(ctx, b, *basic_block, err);
+}
+
+gboolean builder_push(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+    GtkMl_S *args = gtk_ml_cdr(*stmt);
+
+    if (args->kind == GTKML_S_NIL && gtk_ml_cdr(args)->kind == GTKML_S_NIL) {
+        *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, (*stmt)->span.ptr != NULL, (*stmt)->span.line, (*stmt)->span.col, 0);
+        return 0;
+    }
+
+    GtkMl_S **array = &gtk_ml_car(args);
+    GtkMl_S **value = &gtk_ml_cdar(args);
+
+    if (!compile_expression(ctx, b, basic_block, err, value, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
+        return 0;
+    }
+    if (!compile_expression(ctx, b, basic_block, err, array, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
+        return 0;
+    }
+    return gtk_ml_build_array_push(ctx, b, *basic_block, err);
+}
+
+gboolean builder_pop(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+    GtkMl_S *args = gtk_ml_cdr(*stmt);
+
+    if (args->kind == GTKML_S_NIL && gtk_ml_cdr(args)->kind == GTKML_S_NIL) {
+        *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, (*stmt)->span.ptr != NULL, (*stmt)->span.line, (*stmt)->span.col, 0);
+        return 0;
+    }
+
+    GtkMl_S **array = &gtk_ml_car(args);
+
+    if (!compile_expression(ctx, b, basic_block, err, array, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
+        return 0;
+    }
+    return gtk_ml_build_array_pop(ctx, b, *basic_block, err);
 }
 
 gboolean builder_add(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
@@ -4078,6 +4231,186 @@ gboolean gtk_ml_build_assignvar_imm(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_
     basic_block->exec[basic_block->len_exec].imm.cond = gtk_ml_builder_clear_cond(b);
     basic_block->exec[basic_block->len_exec].imm.category = GTKML_I_IMM;
     basic_block->exec[basic_block->len_exec].imm.opcode = GTKML_II_ASSIGNVAR_IMM;
+    ++basic_block->len_exec;
+
+    return 1;
+}
+
+gboolean gtk_ml_build_len(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err) {
+    (void) ctx;
+    (void) err;
+
+    if (basic_block->len_exec == basic_block->cap_exec) {
+        basic_block->cap_exec *= 2;
+        basic_block->exec = realloc(basic_block->exec, sizeof(GtkMl_Instruction) * basic_block->cap_exec);
+    }
+
+    basic_block->exec[basic_block->len_exec].instr = 0;
+    basic_block->exec[basic_block->len_exec].imm.cond = gtk_ml_builder_clear_cond(b);
+    basic_block->exec[basic_block->len_exec].imm.category = GTKML_I_IMM;
+    basic_block->exec[basic_block->len_exec].imm.opcode = GTKML_II_LEN;
+    ++basic_block->len_exec;
+
+    return 1;
+}
+
+gboolean gtk_ml_build_array_index(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err) {
+    (void) ctx;
+    (void) err;
+
+    if (basic_block->len_exec == basic_block->cap_exec) {
+        basic_block->cap_exec *= 2;
+        basic_block->exec = realloc(basic_block->exec, sizeof(GtkMl_Instruction) * basic_block->cap_exec);
+    }
+
+    basic_block->exec[basic_block->len_exec].instr = 0;
+    basic_block->exec[basic_block->len_exec].imm.cond = gtk_ml_builder_clear_cond(b);
+    basic_block->exec[basic_block->len_exec].imm.category = GTKML_I_IMM;
+    basic_block->exec[basic_block->len_exec].imm.opcode = GTKML_II_ARRAY_INDEX;
+    ++basic_block->len_exec;
+
+    return 1;
+}
+
+gboolean gtk_ml_build_array_push(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err) {
+    (void) ctx;
+    (void) err;
+
+    if (basic_block->len_exec == basic_block->cap_exec) {
+        basic_block->cap_exec *= 2;
+        basic_block->exec = realloc(basic_block->exec, sizeof(GtkMl_Instruction) * basic_block->cap_exec);
+    }
+
+    basic_block->exec[basic_block->len_exec].instr = 0;
+    basic_block->exec[basic_block->len_exec].imm.cond = gtk_ml_builder_clear_cond(b);
+    basic_block->exec[basic_block->len_exec].imm.category = GTKML_I_IMM;
+    basic_block->exec[basic_block->len_exec].imm.opcode = GTKML_II_ARRAY_PUSH;
+    ++basic_block->len_exec;
+
+    return 1;
+}
+
+gboolean gtk_ml_build_array_pop(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err) {
+    (void) ctx;
+    (void) err;
+
+    if (basic_block->len_exec == basic_block->cap_exec) {
+        basic_block->cap_exec *= 2;
+        basic_block->exec = realloc(basic_block->exec, sizeof(GtkMl_Instruction) * basic_block->cap_exec);
+    }
+
+    basic_block->exec[basic_block->len_exec].instr = 0;
+    basic_block->exec[basic_block->len_exec].imm.cond = gtk_ml_builder_clear_cond(b);
+    basic_block->exec[basic_block->len_exec].imm.category = GTKML_I_IMM;
+    basic_block->exec[basic_block->len_exec].imm.opcode = GTKML_II_ARRAY_POP;
+    ++basic_block->len_exec;
+
+    return 1;
+}
+
+gboolean gtk_ml_build_map_get(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err) {
+    (void) ctx;
+    (void) err;
+
+    if (basic_block->len_exec == basic_block->cap_exec) {
+        basic_block->cap_exec *= 2;
+        basic_block->exec = realloc(basic_block->exec, sizeof(GtkMl_Instruction) * basic_block->cap_exec);
+    }
+
+    basic_block->exec[basic_block->len_exec].instr = 0;
+    basic_block->exec[basic_block->len_exec].imm.cond = gtk_ml_builder_clear_cond(b);
+    basic_block->exec[basic_block->len_exec].imm.category = GTKML_I_IMM;
+    basic_block->exec[basic_block->len_exec].imm.opcode = GTKML_II_MAP_GET;
+    ++basic_block->len_exec;
+
+    return 1;
+}
+
+gboolean gtk_ml_build_map_insert(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err) {
+    (void) ctx;
+    (void) err;
+
+    if (basic_block->len_exec == basic_block->cap_exec) {
+        basic_block->cap_exec *= 2;
+        basic_block->exec = realloc(basic_block->exec, sizeof(GtkMl_Instruction) * basic_block->cap_exec);
+    }
+
+    basic_block->exec[basic_block->len_exec].instr = 0;
+    basic_block->exec[basic_block->len_exec].imm.cond = gtk_ml_builder_clear_cond(b);
+    basic_block->exec[basic_block->len_exec].imm.category = GTKML_I_IMM;
+    basic_block->exec[basic_block->len_exec].imm.opcode = GTKML_II_MAP_INSERT;
+    ++basic_block->len_exec;
+
+    return 1;
+}
+
+gboolean gtk_ml_build_map_delete(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err) {
+    (void) ctx;
+    (void) err;
+
+    if (basic_block->len_exec == basic_block->cap_exec) {
+        basic_block->cap_exec *= 2;
+        basic_block->exec = realloc(basic_block->exec, sizeof(GtkMl_Instruction) * basic_block->cap_exec);
+    }
+
+    basic_block->exec[basic_block->len_exec].instr = 0;
+    basic_block->exec[basic_block->len_exec].imm.cond = gtk_ml_builder_clear_cond(b);
+    basic_block->exec[basic_block->len_exec].imm.category = GTKML_I_IMM;
+    basic_block->exec[basic_block->len_exec].imm.opcode = GTKML_II_MAP_DELETE;
+    ++basic_block->len_exec;
+
+    return 1;
+}
+
+gboolean gtk_ml_build_set_contains(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err) {
+    (void) ctx;
+    (void) err;
+
+    if (basic_block->len_exec == basic_block->cap_exec) {
+        basic_block->cap_exec *= 2;
+        basic_block->exec = realloc(basic_block->exec, sizeof(GtkMl_Instruction) * basic_block->cap_exec);
+    }
+
+    basic_block->exec[basic_block->len_exec].instr = 0;
+    basic_block->exec[basic_block->len_exec].imm.cond = gtk_ml_builder_clear_cond(b);
+    basic_block->exec[basic_block->len_exec].imm.category = GTKML_I_IMM;
+    basic_block->exec[basic_block->len_exec].imm.opcode = GTKML_II_SET_CONTAINS;
+    ++basic_block->len_exec;
+
+    return 1;
+}
+
+gboolean gtk_ml_build_set_insert(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err) {
+    (void) ctx;
+    (void) err;
+
+    if (basic_block->len_exec == basic_block->cap_exec) {
+        basic_block->cap_exec *= 2;
+        basic_block->exec = realloc(basic_block->exec, sizeof(GtkMl_Instruction) * basic_block->cap_exec);
+    }
+
+    basic_block->exec[basic_block->len_exec].instr = 0;
+    basic_block->exec[basic_block->len_exec].imm.cond = gtk_ml_builder_clear_cond(b);
+    basic_block->exec[basic_block->len_exec].imm.category = GTKML_I_IMM;
+    basic_block->exec[basic_block->len_exec].imm.opcode = GTKML_II_SET_INSERT;
+    ++basic_block->len_exec;
+
+    return 1;
+}
+
+gboolean gtk_ml_build_set_delete(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err) {
+    (void) ctx;
+    (void) err;
+
+    if (basic_block->len_exec == basic_block->cap_exec) {
+        basic_block->cap_exec *= 2;
+        basic_block->exec = realloc(basic_block->exec, sizeof(GtkMl_Instruction) * basic_block->cap_exec);
+    }
+
+    basic_block->exec[basic_block->len_exec].instr = 0;
+    basic_block->exec[basic_block->len_exec].imm.cond = gtk_ml_builder_clear_cond(b);
+    basic_block->exec[basic_block->len_exec].imm.category = GTKML_I_IMM;
+    basic_block->exec[basic_block->len_exec].imm.opcode = GTKML_II_SET_DELETE;
     ++basic_block->len_exec;
 
     return 1;
@@ -5770,6 +6103,16 @@ GTKML_PRIVATE GtkMl_S *vm_std_emit_bytecode(GtkMl_Context *ctx, GtkMl_S **err, G
     const char *bc_var_imm = "var-imm";
     const char *bc_getvar_imm = "getvar-imm";
     const char *bc_assignvar_imm = "assignvar-imm";
+    const char *bc_length = "len";
+    const char *bc_array_index = "array-index";
+    const char *bc_array_push = "array-push";
+    const char *bc_array_pop = "array-pop";
+    const char *bc_map_get = "map-get";
+    const char *bc_map_insert = "map-insert";
+    const char *bc_map_delete = "map-delete";
+    const char *bc_set_contains = "set-contains";
+    const char *bc_set_insert = "set-insert";
+    const char *bc_set_delete = "set-delete";
     const char *bc_call_std = "call-std";
     const char *bc_call = "call";
     const char *bc_branch_absolute = "branch-absolute";
@@ -5855,6 +6198,26 @@ GTKML_PRIVATE GtkMl_S *vm_std_emit_bytecode(GtkMl_Context *ctx, GtkMl_S **err, G
         return gtk_ml_build_getvar_imm(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
     } else if (strlen(bc_assignvar_imm) == bc_len && strncmp(bc_ptr, bc_assignvar_imm, bc_len) == 0) {
         return gtk_ml_build_assignvar_imm(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_length) == bc_len && strncmp(bc_ptr, bc_length, bc_len) == 0) {
+        return gtk_ml_build_len(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_array_index) == bc_len && strncmp(bc_ptr, bc_array_index, bc_len) == 0) {
+        return gtk_ml_build_array_index(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_array_push) == bc_len && strncmp(bc_ptr, bc_array_push, bc_len) == 0) {
+        return gtk_ml_build_array_push(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_array_pop) == bc_len && strncmp(bc_ptr, bc_array_pop, bc_len) == 0) {
+        return gtk_ml_build_array_pop(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_map_get) == bc_len && strncmp(bc_ptr, bc_map_get, bc_len) == 0) {
+        return gtk_ml_build_map_get(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_map_insert) == bc_len && strncmp(bc_ptr, bc_map_insert, bc_len) == 0) {
+        return gtk_ml_build_map_insert(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_map_delete) == bc_len && strncmp(bc_ptr, bc_map_delete, bc_len) == 0) {
+        return gtk_ml_build_map_delete(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_set_contains) == bc_len && strncmp(bc_ptr, bc_set_contains, bc_len) == 0) {
+        return gtk_ml_build_set_contains(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_set_insert) == bc_len && strncmp(bc_ptr, bc_set_insert, bc_len) == 0) {
+        return gtk_ml_build_set_insert(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else if (strlen(bc_set_delete) == bc_len && strncmp(bc_ptr, bc_set_delete, bc_len) == 0) {
+        return gtk_ml_build_set_delete(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
     } else if (strlen(bc_call_std) == bc_len && strncmp(bc_ptr, bc_call_std, bc_len) == 0) {
         if (!imm) {
             *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
@@ -6942,6 +7305,233 @@ gboolean gtk_ml_ii_assignvar_imm(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction 
     GtkMl_S *var = gtk_ml_pop(vm->ctx);
     var->value.s_var.expr = newvalue;
     gtk_ml_push(vm->ctx, var);
+
+    PC_INCREMENT;
+    return 1;
+}
+
+gboolean gtk_ml_ii_len(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr) {
+    (void) err;
+    (void) instr;
+
+    GtkMl_S *container = gtk_ml_pop(vm->ctx);
+    switch (container->kind) {
+    case GTKML_S_ARRAY:
+        gtk_ml_push(vm->ctx, new_int(vm->ctx, NULL, gtk_ml_array_len(&container->value.s_array.array)));
+        break;
+    case GTKML_S_MAP:
+        gtk_ml_push(vm->ctx, new_int(vm->ctx, NULL, gtk_ml_hash_trie_len(&container->value.s_map.map)));
+        break;
+    case GTKML_S_SET:
+        gtk_ml_push(vm->ctx, new_int(vm->ctx, NULL, gtk_ml_hash_set_len(&container->value.s_set.set)));
+        break;
+    default:
+        *err = gtk_ml_error(vm->ctx, "container-error", GTKML_ERR_CONTAINER_ERROR, 0, 0, 0, 0);
+        return 0;
+    }
+
+    PC_INCREMENT;
+    return 1;
+}
+
+gboolean gtk_ml_ii_array_index(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr) {
+    (void) err;
+    (void) instr;
+
+    GtkMl_S *index = gtk_ml_pop(vm->ctx);
+    GtkMl_S *container = gtk_ml_pop(vm->ctx);
+
+    if (index->kind != GTKML_S_INT) {
+        *err = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+        return 0;
+    }
+
+    switch (container->kind) {
+    case GTKML_S_ARRAY:
+        gtk_ml_push(vm->ctx, gtk_ml_array_get(&container->value.s_array.array, index->value.s_int.value));
+        break;
+    default:
+        *err = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+        return 0;
+    }
+
+    PC_INCREMENT;
+    return 1;
+}
+
+gboolean gtk_ml_ii_array_push(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr) {
+    (void) err;
+    (void) instr;
+
+    GtkMl_S *value = gtk_ml_pop(vm->ctx);
+    GtkMl_S *container = gtk_ml_pop(vm->ctx);
+    GtkMl_S *result = new_array(vm->ctx, NULL);
+    gtk_ml_del_array(vm->ctx, &result->value.s_array.array, gtk_ml_delete_value_reference);
+
+    switch (container->kind) {
+    case GTKML_S_ARRAY:
+        gtk_ml_array_push(&result->value.s_array.array, &container->value.s_array.array, value);
+        gtk_ml_push(vm->ctx, result);
+        break;
+    default:
+        *err = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+        return 0;
+    }
+
+    PC_INCREMENT;
+    return 1;
+}
+
+gboolean gtk_ml_ii_array_pop(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr) {
+    (void) err;
+    (void) instr;
+
+    GtkMl_S *container = gtk_ml_pop(vm->ctx);
+    GtkMl_S *result = new_array(vm->ctx, NULL);
+    gtk_ml_del_array(vm->ctx, &result->value.s_array.array, gtk_ml_delete_value_reference);
+
+    switch (container->kind) {
+    case GTKML_S_ARRAY:
+        gtk_ml_array_pop(&result->value.s_array.array, &container->value.s_array.array);
+        gtk_ml_push(vm->ctx, result);
+        break;
+    default:
+        *err = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+        return 0;
+    }
+
+    PC_INCREMENT;
+    return 1;
+}
+
+gboolean gtk_ml_ii_map_get(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr) {
+    (void) err;
+    (void) instr;
+
+    GtkMl_S *key = gtk_ml_pop(vm->ctx);
+    GtkMl_S *container = gtk_ml_pop(vm->ctx);
+
+    switch (container->kind) {
+    case GTKML_S_MAP:
+        gtk_ml_push(vm->ctx, gtk_ml_hash_trie_get(&container->value.s_map.map, key));
+        break;
+    default:
+        *err = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+        return 0;
+    }
+
+    PC_INCREMENT;
+    return 1;
+}
+
+gboolean gtk_ml_ii_map_insert(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr) {
+    (void) err;
+    (void) instr;
+
+    GtkMl_S *value = gtk_ml_pop(vm->ctx);
+    GtkMl_S *key = gtk_ml_pop(vm->ctx);
+    GtkMl_S *container = gtk_ml_pop(vm->ctx);
+    GtkMl_S *result = new_map(vm->ctx, NULL, container->value.s_map.metamap);
+    gtk_ml_del_hash_trie(vm->ctx, &result->value.s_map.map, gtk_ml_delete_void_reference);
+
+    switch (container->kind) {
+    case GTKML_S_ARRAY:
+        gtk_ml_hash_trie_insert(&result->value.s_map.map, &container->value.s_map.map, key, value);
+        gtk_ml_push(vm->ctx, result);
+        break;
+    default:
+        *err = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+        return 0;
+    }
+
+    PC_INCREMENT;
+    return 1;
+}
+
+gboolean gtk_ml_ii_map_delete(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr) {
+    (void) err;
+    (void) instr;
+
+    GtkMl_S *key = gtk_ml_pop(vm->ctx);
+    GtkMl_S *container = gtk_ml_pop(vm->ctx);
+    GtkMl_S *result = new_map(vm->ctx, NULL, container->value.s_map.metamap);
+    gtk_ml_del_hash_trie(vm->ctx, &result->value.s_map.map, gtk_ml_delete_void_reference);
+
+    switch (container->kind) {
+    case GTKML_S_ARRAY:
+        gtk_ml_hash_trie_delete(&result->value.s_map.map, &container->value.s_map.map, key);
+        gtk_ml_push(vm->ctx, result);
+        break;
+    default:
+        *err = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+        return 0;
+    }
+
+    PC_INCREMENT;
+    return 1;
+}
+
+gboolean gtk_ml_ii_set_contains(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr) {
+    (void) err;
+    (void) instr;
+
+    GtkMl_S *key = gtk_ml_pop(vm->ctx);
+    GtkMl_S *container = gtk_ml_pop(vm->ctx);
+
+    switch (container->kind) {
+    case GTKML_S_SET:
+        gtk_ml_push(vm->ctx, gtk_ml_hash_set_contains(&container->value.s_set.set, key)? new_true(vm->ctx, NULL) : new_false(vm->ctx, NULL));
+        break;
+    default:
+        *err = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+        return 0;
+    }
+
+    PC_INCREMENT;
+    return 1;
+}
+
+gboolean gtk_ml_ii_set_insert(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr) {
+    (void) err;
+    (void) instr;
+
+    GtkMl_S *key = gtk_ml_pop(vm->ctx);
+    GtkMl_S *container = gtk_ml_pop(vm->ctx);
+    GtkMl_S *result = new_set(vm->ctx, NULL);
+    gtk_ml_del_hash_set(vm->ctx, &result->value.s_set.set, gtk_ml_delete_void_reference);
+
+    switch (container->kind) {
+    case GTKML_S_ARRAY:
+        gtk_ml_hash_set_insert(&result->value.s_set.set, &container->value.s_set.set, key);
+        gtk_ml_push(vm->ctx, result);
+        break;
+    default:
+        *err = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+        return 0;
+    }
+
+    PC_INCREMENT;
+    return 1;
+}
+
+gboolean gtk_ml_ii_set_delete(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction instr) {
+    (void) err;
+    (void) instr;
+
+    GtkMl_S *key = gtk_ml_pop(vm->ctx);
+    GtkMl_S *container = gtk_ml_pop(vm->ctx);
+    GtkMl_S *result = new_set(vm->ctx, NULL);
+    gtk_ml_del_hash_set(vm->ctx, &result->value.s_set.set, gtk_ml_delete_void_reference);
+
+    switch (container->kind) {
+    case GTKML_S_ARRAY:
+        gtk_ml_hash_set_delete(&result->value.s_set.set, &container->value.s_set.set, key);
+        gtk_ml_push(vm->ctx, result);
+        break;
+    default:
+        *err = gtk_ml_error(vm->ctx, "type-error", GTKML_ERR_TYPE_ERROR, 0, 0, 0, 0);
+        return 0;
+    }
 
     PC_INCREMENT;
     return 1;

--- a/src/gtk-ml.c
+++ b/src/gtk-ml.c
@@ -79,39 +79,44 @@ GTKML_PRIVATE void delete(GtkMl_Context *ctx, GtkMl_S *s);
 GTKML_PRIVATE void del(GtkMl_Context *ctx, GtkMl_S *s);
 GTKML_PRIVATE void gtk_ml_object_unref(GtkMl_Context *ctx, void *obj);
 
-GTKML_PRIVATE gboolean builder_do(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_lambda(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_macro(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_cond(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_while(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_add(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_sub(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_mul(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_div(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_mod(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_bitnot(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_bitand(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_bitor(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_bitxor(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_cmp(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_var(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_vararg(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_quote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_quasiquote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_unquote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_define(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_define_macro(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_application(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_new_window(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_setmetamap(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_getmetamap(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_getvar(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_assignvar(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean builder_error(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_compile_expr(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_emit_bytecode(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_do(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_lambda(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_macro(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_cond(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_while(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_add(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_sub(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_mul(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_div(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_mod(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_bitnot(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_bitand(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_bitor(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_bitxor(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_cmp(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_var(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_vararg(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_quote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_quasiquote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_unquote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_define(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_define_macro(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_define_intrinsic(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_application(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_new_window(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_setmetamap(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_getmetamap(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_getvar(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_assignvar(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean builder_error(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
 
 GTKML_PRIVATE GtkMl_S *vm_std_application(GtkMl_Context *ctx, GtkMl_S **err, GtkMl_S *expr);
 GTKML_PRIVATE GtkMl_S *vm_std_new_window(GtkMl_Context *ctx, GtkMl_S **err, GtkMl_S *expr);
 GTKML_PRIVATE GtkMl_S *vm_std_error(GtkMl_Context *ctx, GtkMl_S **err, GtkMl_S *expr);
+GTKML_PRIVATE GtkMl_S *vm_std_compile_expr(GtkMl_Context *ctx, GtkMl_S **err, GtkMl_S *expr);
+GTKML_PRIVATE GtkMl_S *vm_std_emit_bytecode(GtkMl_Context *ctx, GtkMl_S **err, GtkMl_S *expr);
 
 GTKML_PRIVATE gboolean gtk_ml_vm_run(GtkMl_Vm *vm, GtkMl_S **err);
 
@@ -404,6 +409,8 @@ GTKML_PRIVATE GtkMl_S *(*STD[])(GtkMl_Context *, GtkMl_S **, GtkMl_S *) = {
     [GTKML_STD_APPLICATION] = vm_std_application,
     [GTKML_STD_NEW_WINDOW] = vm_std_new_window,
     [GTKML_STD_ERROR] = vm_std_error,
+    [GTKML_STD_COMPILE_EXPR] = vm_std_compile_expr,
+    [GTKML_STD_EMIT_BYTECODE] = vm_std_emit_bytecode,
 };
 
 GTKML_PRIVATE GtkMl_Hasher DEFAULT_HASHER = {
@@ -433,6 +440,7 @@ GtkMl_Context *gtk_ml_new_context() {
     ctx->top_scope = &gtk_ml_car(ctx->bindings);
 
     gtk_ml_define(ctx, new_symbol(ctx, NULL, 0, "flags-none", 10), new_int(ctx, NULL, G_APPLICATION_FLAGS_NONE));
+    gtk_ml_define(ctx, new_symbol(ctx, NULL, 0, "cond-none", 9), new_int(ctx, NULL, GTKML_F_NONE));
 
     ctx->parser.readers = malloc(sizeof(GtkMl_Reader) * 64);
     ctx->parser.len_reader = 0;
@@ -585,6 +593,9 @@ GtkMl_Builder *gtk_ml_new_builder() {
     b->counter = 0;
     b->flags = 0;
 
+    b->intr_ctx = gtk_ml_new_context();
+    b->intr_vm = b->intr_ctx->vm;
+
     b->macro_ctx = gtk_ml_new_context();
     b->macro_vm = b->macro_ctx->vm;
 
@@ -592,10 +603,29 @@ GtkMl_Builder *gtk_ml_new_builder() {
     b->len_builder = 0;
     b->cap_builder = 64;
 
+    char *name_compile_expr = malloc(strlen("compile-expr") + 1);
+    strcpy(name_compile_expr, "compile-expr");
+    b->builders[b->len_builder].name = name_compile_expr;
+    b->builders[b->len_builder].fn = builder_compile_expr;
+    b->builders[b->len_builder].require_intrinsic = 1;
+    b->builders[b->len_builder].require_macro = 0;
+    b->builders[b->len_builder].require_runtime = 0;
+    ++b->len_builder;
+
+    char *name_emit_bytecode = malloc(strlen("emit-bytecode") + 1);
+    strcpy(name_emit_bytecode, "emit-bytecode");
+    b->builders[b->len_builder].name = name_emit_bytecode;
+    b->builders[b->len_builder].fn = builder_emit_bytecode;
+    b->builders[b->len_builder].require_intrinsic = 1;
+    b->builders[b->len_builder].require_macro = 0;
+    b->builders[b->len_builder].require_runtime = 0;
+    ++b->len_builder;
+
     char *name_do = malloc(strlen("do") + 1);
     strcpy(name_do, "do");
     b->builders[b->len_builder].name = name_do;
     b->builders[b->len_builder].fn = builder_do;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -604,6 +634,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_lambda, "lambda");
     b->builders[b->len_builder].name = name_lambda;
     b->builders[b->len_builder].fn = builder_lambda;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -612,6 +643,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_macro, "macro");
     b->builders[b->len_builder].name = name_macro;
     b->builders[b->len_builder].fn = builder_macro;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 1;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -620,6 +652,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_cond, "cond");
     b->builders[b->len_builder].name = name_cond;
     b->builders[b->len_builder].fn = builder_cond;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -628,6 +661,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_while, "while");
     b->builders[b->len_builder].name = name_while;
     b->builders[b->len_builder].fn = builder_while;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -636,6 +670,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_add, "+");
     b->builders[b->len_builder].name = name_add;
     b->builders[b->len_builder].fn = builder_add;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -644,6 +679,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_sub, "-");
     b->builders[b->len_builder].name = name_sub;
     b->builders[b->len_builder].fn = builder_sub;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -652,6 +688,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_mul, "*");
     b->builders[b->len_builder].name = name_mul;
     b->builders[b->len_builder].fn = builder_mul;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -660,6 +697,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_div, "/");
     b->builders[b->len_builder].name = name_div;
     b->builders[b->len_builder].fn = builder_div;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -668,6 +706,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_mod, "%");
     b->builders[b->len_builder].name = name_mod;
     b->builders[b->len_builder].fn = builder_mod;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -676,6 +715,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_bitnot, "bit-not");
     b->builders[b->len_builder].name = name_bitnot;
     b->builders[b->len_builder].fn = builder_bitnot;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -684,6 +724,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_bitand, "bit-and");
     b->builders[b->len_builder].name = name_bitand;
     b->builders[b->len_builder].fn = builder_bitand;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -692,6 +733,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_bitor, "bit-or");
     b->builders[b->len_builder].name = name_bitor;
     b->builders[b->len_builder].fn = builder_bitor;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -700,6 +742,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_bitxor, "bit-xor");
     b->builders[b->len_builder].name = name_bitxor;
     b->builders[b->len_builder].fn = builder_bitxor;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -708,6 +751,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_cmp, "cmp");
     b->builders[b->len_builder].name = name_cmp;
     b->builders[b->len_builder].fn = builder_cmp;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -716,6 +760,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_var, "var");
     b->builders[b->len_builder].name = name_var;
     b->builders[b->len_builder].fn = builder_var;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -724,6 +769,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_vararg, "vararg");
     b->builders[b->len_builder].name = name_vararg;
     b->builders[b->len_builder].fn = builder_vararg;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -732,6 +778,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_quote, "quote");
     b->builders[b->len_builder].name = name_quote;
     b->builders[b->len_builder].fn = builder_quote;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -740,6 +787,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_quasiquote, "quasiquote");
     b->builders[b->len_builder].name = name_quasiquote;
     b->builders[b->len_builder].fn = builder_quasiquote;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -748,6 +796,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_unquote, "unquote");
     b->builders[b->len_builder].name = name_unquote;
     b->builders[b->len_builder].fn = builder_unquote;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -756,6 +805,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_define, "define");
     b->builders[b->len_builder].name = name_define;
     b->builders[b->len_builder].fn = builder_define;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -764,6 +814,16 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_define_macro, "define-macro");
     b->builders[b->len_builder].name = name_define_macro;
     b->builders[b->len_builder].fn = builder_define_macro;
+    b->builders[b->len_builder].require_intrinsic = 0;
+    b->builders[b->len_builder].require_macro = 0;
+    b->builders[b->len_builder].require_runtime = 0;
+    ++b->len_builder;
+
+    char *name_define_intrinsic = malloc(strlen("define-intrinsic") + 1);
+    strcpy(name_define_intrinsic, "define-intrinsic");
+    b->builders[b->len_builder].name = name_define_intrinsic;
+    b->builders[b->len_builder].fn = builder_define_intrinsic;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -772,6 +832,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_application, "Application");
     b->builders[b->len_builder].name = name_application;
     b->builders[b->len_builder].fn = builder_application;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 1;
     ++b->len_builder;
@@ -780,6 +841,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_new_window, "new-window");
     b->builders[b->len_builder].name = name_new_window;
     b->builders[b->len_builder].fn = builder_new_window;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 1;
     ++b->len_builder;
@@ -788,6 +850,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_setmetamap, "setmetamap");
     b->builders[b->len_builder].name = name_setmetamap;
     b->builders[b->len_builder].fn = builder_setmetamap;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -796,6 +859,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_getmetamap, "getmetamap");
     b->builders[b->len_builder].name = name_getmetamap;
     b->builders[b->len_builder].fn = builder_getmetamap;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -804,6 +868,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_getvar, "get");
     b->builders[b->len_builder].name = name_getvar;
     b->builders[b->len_builder].fn = builder_getvar;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -812,6 +877,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_assignvar, "assign");
     b->builders[b->len_builder].name = name_assignvar;
     b->builders[b->len_builder].fn = builder_assignvar;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -820,6 +886,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     strcpy(name_error, "error");
     b->builders[b->len_builder].name = name_error;
     b->builders[b->len_builder].fn = builder_error;
+    b->builders[b->len_builder].require_intrinsic = 0;
     b->builders[b->len_builder].require_macro = 0;
     b->builders[b->len_builder].require_runtime = 0;
     ++b->len_builder;
@@ -827,7 +894,7 @@ GtkMl_Builder *gtk_ml_new_builder() {
     return b;
 }
 
-gboolean build(GtkMl_Context *ctx, GtkMl_Program *out, GtkMl_S **err, GtkMl_Builder *b, gboolean macro) {
+gboolean build(GtkMl_Context *ctx, GtkMl_Program *out, GtkMl_S **err, GtkMl_Builder *b, GtkMl_Stage stage) {
     size_t n = 0;
     size_t n_static = b->len_static;
     for (size_t i = 0; i < b->len_bb; i++) {
@@ -935,7 +1002,8 @@ gboolean build(GtkMl_Context *ctx, GtkMl_Program *out, GtkMl_S **err, GtkMl_Buil
         }
     }
 
-    if (macro) {
+    switch (stage) {
+    case GTKML_STAGE_INTR:
         for (size_t i = 0; i < b->len_bb; i++) {
             free(b->basic_blocks[i].exec);
         }
@@ -947,7 +1015,31 @@ gboolean build(GtkMl_Context *ctx, GtkMl_Program *out, GtkMl_S **err, GtkMl_Buil
         out->n_exec = n;
         out->statics = statics;
         out->n_static = n_static;
-    } else {
+        break;
+    case GTKML_STAGE_MACRO: {
+        // first we transfer the values from the intr context into the macro context
+        GtkMl_S *intr_values = b->intr_ctx->first;
+        b->intr_ctx->first = NULL;
+        GtkMl_S **prev = &b->macro_ctx->first;
+        while (*prev) {
+            prev = &(*prev)->next;
+        }
+        *prev = intr_values;
+        // then it's safe to delete the intr context and vm
+
+        for (size_t i = 0; i < b->len_bb; i++) {
+            free(b->basic_blocks[i].exec);
+        }
+        b->len_bb = 0;
+        b->len_static = 1;
+
+        out->start = NULL;
+        out->exec = result;
+        out->n_exec = n;
+        out->statics = statics;
+        out->n_static = n_static;
+    } break;
+    case GTKML_STAGE_RUNTIME: {
         // first we transfer the values from the macro context into the real context
         GtkMl_S *macro_values = b->macro_ctx->first;
         b->macro_ctx->first = NULL;
@@ -958,6 +1050,8 @@ gboolean build(GtkMl_Context *ctx, GtkMl_Program *out, GtkMl_S **err, GtkMl_Buil
         *prev = macro_values;
         // then it's safe to delete the macro context and vm
         gtk_ml_del_context(b->macro_ctx);
+        // and the intr context
+        gtk_ml_del_context(b->intr_ctx);
 
         for (size_t i = 0; i < b->len_bb; i++) {
             free(b->basic_blocks[i].exec);
@@ -977,17 +1071,22 @@ gboolean build(GtkMl_Context *ctx, GtkMl_Program *out, GtkMl_S **err, GtkMl_Buil
         out->n_exec = n;
         out->statics = statics;
         out->n_static = n_static;
+    } break;
     }
 
     return 1;
 }
 
+gboolean gtk_ml_build_intrinsics(GtkMl_Program *out, GtkMl_S **err, GtkMl_Builder *b) {
+    return build(NULL, out, err, b, GTKML_STAGE_INTR);
+}
+
 gboolean gtk_ml_build_macros(GtkMl_Program *out, GtkMl_S **err, GtkMl_Builder *b) {
-    return build(NULL, out, err, b, 1);
+    return build(NULL, out, err, b, GTKML_STAGE_MACRO);
 }
 
 gboolean gtk_ml_build(GtkMl_Context *ctx, GtkMl_Program *out, GtkMl_S **err, GtkMl_Builder *b) {
-    return build(ctx, out, err, b, 0);
+    return build(ctx, out, err, b, GTKML_STAGE_RUNTIME);
 }
 
 GTKML_PUBLIC void gtk_ml_del_program(GtkMl_Program* program) {
@@ -2008,16 +2107,17 @@ GtkMl_S *gtk_ml_loads(GtkMl_Context *ctx, GtkMl_S **err, const char *src) {
 }
 
 GTKML_PRIVATE gboolean compile_std_call(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, uint64_t function, GtkMl_S *args, gboolean compile_first);
-GTKML_PRIVATE gboolean compile_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt);
-GTKML_PRIVATE gboolean compile_program(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, const char *linkage_name, GtkMl_S *stmt, gboolean ret);
+GTKML_PRIVATE gboolean compile_runtime_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt);
+GTKML_PRIVATE gboolean compile_runtime_program(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, const char *linkage_name, GtkMl_S *stmt, gboolean ret);
 
-GTKML_PRIVATE gboolean compile_cond_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean compile_macro_quasi_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S *stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean compile_macro_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean compile_macro_body(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S *stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
-GTKML_PRIVATE gboolean compile_macro_program(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, const char *linkage_name, GtkMl_S *stmt, gboolean ret, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean compile_cond_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean compile_quasi_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S *stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean compile_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean compile_body(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S *stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
+GTKML_PRIVATE gboolean compile_program(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, const char *linkage_name, GtkMl_S *stmt, gboolean ret, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion);
 
-gboolean builder_application(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_application(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+    (void) allow_intr;
     (void) allow_macro;
     (void) allow_runtime;
     (void) allow_macro_expansion;
@@ -2033,7 +2133,8 @@ gboolean builder_application(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBl
     return compile_std_call(ctx, b, basic_block, err, GTKML_STD_APPLICATION, *stmt, 0);
 }
 
-gboolean builder_new_window(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_new_window(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+    (void) allow_intr;
     (void) allow_macro;
     (void) allow_runtime;
     (void) allow_macro_expansion;
@@ -2049,7 +2150,7 @@ gboolean builder_new_window(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlo
     return compile_std_call(ctx, b, basic_block, err, GTKML_STD_NEW_WINDOW, *stmt, 0);
 }
 
-gboolean builder_setmetamap(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_setmetamap(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL || gtk_ml_cdr(args)->kind == GTKML_S_NIL) {
@@ -2060,16 +2161,16 @@ gboolean builder_setmetamap(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlo
     GtkMl_S *map = gtk_ml_car(args);
     GtkMl_S *metamap = gtk_ml_cdar(args);
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, &map, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, &map, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
-    if (!compile_macro_expression(ctx, b, basic_block, err, &metamap, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, &metamap, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_setmm_imm(ctx, b, *basic_block, err);
 }
 
-gboolean builder_getmetamap(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_getmetamap(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL) {
@@ -2079,13 +2180,13 @@ gboolean builder_getmetamap(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlo
 
     GtkMl_S *map = gtk_ml_car(args);
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, &map, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, &map, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_getmm_imm(ctx, b, *basic_block, err);
 }
 
-gboolean builder_getvar(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_getvar(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL) {
@@ -2095,13 +2196,13 @@ gboolean builder_getvar(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *
 
     GtkMl_S *map = gtk_ml_car(args);
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, &map, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, &map, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_getvar_imm(ctx, b, *basic_block, err);
 }
 
-gboolean builder_assignvar(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_assignvar(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL || gtk_ml_cdr(args)->kind == GTKML_S_NIL) {
@@ -2112,16 +2213,17 @@ gboolean builder_assignvar(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBloc
     GtkMl_S *var = gtk_ml_car(args);
     GtkMl_S *newvalue = gtk_ml_cdar(args);
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, &var, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, &var, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
-    if (!compile_macro_expression(ctx, b, basic_block, err, &newvalue, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, &newvalue, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_assignvar_imm(ctx, b, *basic_block, err);
 }
 
-gboolean builder_error(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_error(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+    (void) allow_intr;
     (void) allow_macro;
     (void) allow_runtime;
     (void) allow_macro_expansion;
@@ -2135,7 +2237,7 @@ gboolean builder_error(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **
     return compile_std_call(ctx, b, basic_block, err, GTKML_STD_ERROR, *stmt, 0);
 }
 
-gboolean builder_define(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_define(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL
@@ -2148,7 +2250,7 @@ gboolean builder_define(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *
     if (definition->kind == GTKML_S_SYMBOL) {
         GtkMl_S *name = definition;
         GtkMl_S **value = &gtk_ml_cdar(args);
-        if (!compile_macro_expression(ctx, b, basic_block, err, value, allow_macro, allow_runtime, allow_macro_expansion)) {
+        if (!compile_expression(ctx, b, basic_block, err, value, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
             return 0;
         }
         if (!gtk_ml_build_push_extended_imm(ctx, b, *basic_block, err, gtk_ml_append_static(b, name))) {
@@ -2173,7 +2275,7 @@ gboolean builder_define(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *
         memcpy(linkage_name, name->value.s_symbol.ptr, len);
         linkage_name[len] = 0;
         GtkMl_BasicBlock *bb = gtk_ml_append_basic_block(b, linkage_name);
-        if (!compile_program(ctx, b, &bb, err, linkage_name, lambda, 1)) {
+        if (!compile_runtime_program(ctx, b, &bb, err, linkage_name, lambda, 1)) {
             return 0;
         }
         if (!gtk_ml_build_push_extended_addr(ctx, b, *basic_block, err, gtk_ml_append_static(b, new_string(ctx, NULL, linkage_name, strlen(linkage_name))))) {
@@ -2190,28 +2292,83 @@ gboolean builder_define(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *
 }
 
 
-gboolean builder_define_macro(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_define_macro(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     (void) ctx;
     (void) b;
     (void) basic_block;
     (void) err;
     (void) stmt;
+    (void) allow_intr;
     (void) allow_macro;
     (void) allow_runtime;
     (void) allow_macro_expansion;
     return 1;
 }
 
-gboolean builder_do(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_define_intrinsic(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+    (void) ctx;
+    (void) b;
+    (void) basic_block;
+    (void) err;
+    (void) stmt;
+    (void) allow_intr;
+    (void) allow_macro;
+    (void) allow_runtime;
+    (void) allow_macro_expansion;
+    return 1;
+}
+
+gboolean builder_compile_expr(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+    (void) b;
+    (void) basic_block;
+    (void) allow_intr;
+    (void) allow_macro;
+    (void) allow_runtime;
+    (void) allow_macro_expansion;
+    GtkMl_S *args = gtk_ml_cdr(*stmt);
+
+    if (args->kind == GTKML_S_NIL
+            || gtk_ml_cdr(args)->kind == GTKML_S_NIL
+            || gtk_ml_cddr(args)->kind == GTKML_S_NIL
+            || gtk_ml_cdddr(args)->kind == GTKML_S_NIL) {
+        *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, (*stmt)->span.ptr != NULL, (*stmt)->span.line, (*stmt)->span.col, 0);
+        return 0;
+    }
+
+    return compile_std_call(ctx, b, basic_block, err, GTKML_STD_COMPILE_EXPR, *stmt, 0);
+}
+
+gboolean builder_emit_bytecode(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+    (void) b;
+    (void) basic_block;
+    (void) allow_intr;
+    (void) allow_macro;
+    (void) allow_runtime;
+    (void) allow_macro_expansion;
+    GtkMl_S *args = gtk_ml_cdr(*stmt);
+
+    if (args->kind == GTKML_S_NIL
+            || gtk_ml_cdr(args)->kind == GTKML_S_NIL
+            || gtk_ml_cddr(args)->kind == GTKML_S_NIL
+            || gtk_ml_cdddr(args)->kind == GTKML_S_NIL
+            || gtk_ml_cddddr(args)->kind == GTKML_S_NIL) {
+        *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, (*stmt)->span.ptr != NULL, (*stmt)->span.line, (*stmt)->span.col, 0);
+        return 0;
+    }
+
+    return compile_std_call(ctx, b, basic_block, err, GTKML_STD_EMIT_BYTECODE, *stmt, 0);
+}
+
+gboolean builder_do(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL) {
         GtkMl_S *nil = new_nil(ctx, &(*stmt)->span);
-        return compile_macro_expression(ctx, b, basic_block, err, &nil, allow_macro, allow_runtime, allow_macro_expansion);
+        return compile_expression(ctx, b, basic_block, err, &nil, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
     }
 
     while (args->kind != GTKML_S_NIL) {
-        if (!compile_macro_expression(ctx, b, basic_block, err, &gtk_ml_car(args), allow_macro, allow_runtime, allow_macro_expansion)) {
+        if (!compile_expression(ctx, b, basic_block, err, &gtk_ml_car(args), allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
             return 0;
         }
         args = gtk_ml_cdr(args);
@@ -2225,7 +2382,7 @@ gboolean builder_do(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **bas
     return 1;
 }
 
-gboolean builder_lambda(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_lambda(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL
@@ -2242,10 +2399,10 @@ gboolean builder_lambda(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *
         return 0;
     }
 
-    return compile_macro_expression(ctx, b, basic_block, err, &lambda, allow_macro, allow_runtime, allow_macro_expansion);
+    return compile_expression(ctx, b, basic_block, err, &lambda, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
 }
 
-gboolean builder_macro(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_macro(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL
@@ -2262,10 +2419,10 @@ gboolean builder_macro(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **
         return 0;
     }
 
-    return compile_macro_expression(ctx, b, basic_block, err, &macro, allow_macro, allow_runtime, allow_macro_expansion);
+    return compile_expression(ctx, b, basic_block, err, &macro, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
 }
 
-gboolean builder_cond(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_cond(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
     GtkMl_S *_args = args;
 
@@ -2384,7 +2541,7 @@ gboolean builder_cond(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **b
             break;
         }
 
-        if (!compile_cond_expression(ctx, b, basic_block, err, cond, allow_macro, allow_runtime, allow_macro_expansion)) {
+        if (!compile_cond_expression(ctx, b, basic_block, err, cond, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
             return 0;
         }
         gtk_ml_builder_set_cond(b, GTKML_F_ZERO);
@@ -2408,7 +2565,7 @@ gboolean builder_cond(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **b
         GtkMl_S *cond = gtk_ml_car(args);
         GtkMl_S **body = &gtk_ml_cdar(args);
 
-        if (!compile_macro_expression(ctx, b, &branches[i], err, body, allow_macro, allow_runtime, allow_macro_expansion)) {
+        if (!compile_expression(ctx, b, &branches[i], err, body, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
             return 0;
         }
 
@@ -2434,7 +2591,7 @@ gboolean builder_cond(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **b
     return 1;
 }
 
-gboolean builder_while(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_while(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL) {
@@ -2527,7 +2684,7 @@ gboolean builder_while(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **
     char *end_name = malloc(strlen("while$$end") + 16);
     snprintf(end_name, strlen("while$$end") + 16, "while$%u$end", while_number);
 
-    compile_cond_expression(ctx, b, &cond, err, &gtk_ml_car(args), allow_macro, allow_runtime, allow_macro_expansion);
+    compile_cond_expression(ctx, b, &cond, err, &gtk_ml_car(args), allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
     // if true: jump to body
     gtk_ml_builder_set_cond(b, GTKML_F_ZERO);
     gtk_ml_build_branch_absolute_extended(ctx, b, cond, err, gtk_ml_append_static(b, new_string(ctx, NULL, body_name, strlen(body_name))));
@@ -2539,7 +2696,7 @@ gboolean builder_while(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **
         char *cond_name = malloc(strlen("while$$cond") + 16);
         snprintf(cond_name, strlen("while$$cond") + 16, "while$%u$cond", while_number);
 
-        compile_macro_expression(ctx, b, &body, err, &gtk_ml_car(args), allow_macro, allow_runtime, allow_macro_expansion);
+        compile_expression(ctx, b, &body, err, &gtk_ml_car(args), allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
         gtk_ml_build_branch_absolute_extended(ctx, b, body, err, gtk_ml_append_static(b, new_string(ctx, NULL, cond_name, strlen(cond_name))));
         args = gtk_ml_cdr(args);
     }
@@ -2549,7 +2706,7 @@ gboolean builder_while(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **
     return 1;
 }
 
-gboolean builder_add(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_add(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL && gtk_ml_cdr(args)->kind == GTKML_S_NIL) {
@@ -2560,26 +2717,26 @@ gboolean builder_add(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **ba
     GtkMl_S **lhs = &gtk_ml_car(args);
     GtkMl_S **rhs = &gtk_ml_cdar(args);
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, rhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, rhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
-    if (!compile_macro_expression(ctx, b, basic_block, err, lhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, lhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_add(ctx, b, *basic_block, err);
 }
 
-gboolean builder_sub(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_sub(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind != GTKML_S_NIL && gtk_ml_cdr(args)->kind == GTKML_S_NIL) {
         GtkMl_S **value = &gtk_ml_car(args);
         GtkMl_S *zero = new_int(ctx, &(*stmt)->span, 0);
 
-        if (!compile_macro_expression(ctx, b, basic_block, err, value, allow_macro, allow_runtime, allow_macro_expansion)) {
+        if (!compile_expression(ctx, b, basic_block, err, value, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
             return 0;
         }
-        if (!compile_macro_expression(ctx, b, basic_block, err, &zero, allow_macro, allow_runtime, allow_macro_expansion)) {
+        if (!compile_expression(ctx, b, basic_block, err, &zero, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
             return 0;
         }
         return gtk_ml_build_sub(ctx, b, *basic_block, err);
@@ -2593,16 +2750,16 @@ gboolean builder_sub(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **ba
     GtkMl_S **lhs = &gtk_ml_car(args);
     GtkMl_S **rhs = &gtk_ml_cdar(args);
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, rhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, rhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
-    if (!compile_macro_expression(ctx, b, basic_block, err, lhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, lhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_sub(ctx, b, *basic_block, err);
 }
 
-gboolean builder_mul(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_mul(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL && gtk_ml_cdr(args)->kind == GTKML_S_NIL) {
@@ -2613,16 +2770,16 @@ gboolean builder_mul(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **ba
     GtkMl_S **lhs = &gtk_ml_car(args);
     GtkMl_S **rhs = &gtk_ml_cdar(args);
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, rhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, rhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
-    if (!compile_macro_expression(ctx, b, basic_block, err, lhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, lhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_mul(ctx, b, *basic_block, err);
 }
 
-gboolean builder_div(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_div(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL && gtk_ml_cdr(args)->kind == GTKML_S_NIL) {
@@ -2633,16 +2790,16 @@ gboolean builder_div(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **ba
     GtkMl_S **lhs = &gtk_ml_car(args);
     GtkMl_S **rhs = &gtk_ml_cdar(args);
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, rhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, rhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
-    if (!compile_macro_expression(ctx, b, basic_block, err, lhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, lhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_div(ctx, b, *basic_block, err);
 }
 
-gboolean builder_mod(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_mod(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL && gtk_ml_cdr(args)->kind == GTKML_S_NIL) {
@@ -2653,16 +2810,16 @@ gboolean builder_mod(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **ba
     GtkMl_S **lhs = &gtk_ml_car(args);
     GtkMl_S **rhs = &gtk_ml_cdar(args);
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, rhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, rhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
-    if (!compile_macro_expression(ctx, b, basic_block, err, lhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, lhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_mod(ctx, b, *basic_block, err);
 }
 
-gboolean builder_bitnot(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_bitnot(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL) {
@@ -2673,16 +2830,16 @@ gboolean builder_bitnot(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *
     GtkMl_S **value = &gtk_ml_car(args);
     GtkMl_S *ff = new_int(ctx, &(*stmt)->span, 0xfffffffffffffffful);
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, &ff, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, &ff, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
-    if (!compile_macro_expression(ctx, b, basic_block, err, value, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, value, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_bitxor(ctx, b, *basic_block, err);
 }
 
-gboolean builder_bitand(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_bitand(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL && gtk_ml_cdr(args)->kind == GTKML_S_NIL) {
@@ -2693,16 +2850,16 @@ gboolean builder_bitand(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *
     GtkMl_S **lhs = &gtk_ml_car(args);
     GtkMl_S **rhs = &gtk_ml_cdar(args);
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, rhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, rhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
-    if (!compile_macro_expression(ctx, b, basic_block, err, lhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, lhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_bitand(ctx, b, *basic_block, err);
 }
 
-gboolean builder_bitor(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_bitor(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL && gtk_ml_cdr(args)->kind == GTKML_S_NIL) {
@@ -2713,16 +2870,16 @@ gboolean builder_bitor(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **
     GtkMl_S **lhs = &gtk_ml_car(args);
     GtkMl_S **rhs = &gtk_ml_cdar(args);
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, rhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, rhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
-    if (!compile_macro_expression(ctx, b, basic_block, err, lhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, lhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_bitor(ctx, b, *basic_block, err);
 }
 
-gboolean builder_bitxor(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_bitxor(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL && gtk_ml_cdr(args)->kind == GTKML_S_NIL) {
@@ -2733,21 +2890,21 @@ gboolean builder_bitxor(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *
     GtkMl_S **lhs = &gtk_ml_car(args);
     GtkMl_S **rhs = &gtk_ml_cdar(args);
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, rhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, rhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
-    if (!compile_macro_expression(ctx, b, basic_block, err, lhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, lhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_bitxor(ctx, b, *basic_block, err);
 }
 
-gboolean builder_cmp(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_cmp(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL
-            && gtk_ml_cdr(args)->kind == GTKML_S_NIL
-            && gtk_ml_cddr(args)->kind == GTKML_S_NIL) {
+            || gtk_ml_cdr(args)->kind == GTKML_S_NIL
+            || gtk_ml_cddr(args)->kind == GTKML_S_NIL) {
         *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, (*stmt)->span.ptr != NULL, (*stmt)->span.line, (*stmt)->span.col, 0);
         return 0;
     }
@@ -2773,16 +2930,16 @@ gboolean builder_cmp(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **ba
         return 0;
     }
 
-    if (!compile_macro_expression(ctx, b, basic_block, err, rhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, rhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
-    if (!compile_macro_expression(ctx, b, basic_block, err, lhs, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_expression(ctx, b, basic_block, err, lhs, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
     return gtk_ml_build_cmp(ctx, b, *basic_block, err, gtk_ml_append_static(b, cmp));
 }
 
-gboolean builder_var(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_var(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL) {
@@ -2795,10 +2952,10 @@ gboolean builder_var(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **ba
         return 0;
     }
 
-    return compile_macro_expression(ctx, b, basic_block, err, &var, allow_macro, allow_runtime, allow_macro_expansion);
+    return compile_expression(ctx, b, basic_block, err, &var, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
 }
 
-gboolean builder_vararg(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_vararg(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL) {
@@ -2811,10 +2968,10 @@ gboolean builder_vararg(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *
         return 0;
     }
 
-    return compile_macro_expression(ctx, b, basic_block, err, &vararg, allow_macro, allow_runtime, allow_macro_expansion);
+    return compile_expression(ctx, b, basic_block, err, &vararg, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
 }
 
-gboolean builder_quote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_quote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL) {
@@ -2827,10 +2984,10 @@ gboolean builder_quote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **
         return 0;
     }
 
-    return compile_macro_expression(ctx, b, basic_block, err, &quote, allow_macro, allow_runtime, allow_macro_expansion);
+    return compile_expression(ctx, b, basic_block, err, &quote, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
 }
 
-gboolean builder_quasiquote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_quasiquote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL) {
@@ -2843,10 +3000,10 @@ gboolean builder_quasiquote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlo
         return 0;
     }
 
-    return compile_macro_expression(ctx, b, basic_block, err, &quasiquote, allow_macro, allow_runtime, allow_macro_expansion);
+    return compile_expression(ctx, b, basic_block, err, &quasiquote, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
 }
 
-gboolean builder_unquote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean builder_unquote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     GtkMl_S *args = gtk_ml_cdr(*stmt);
 
     if (args->kind == GTKML_S_NIL) {
@@ -2859,10 +3016,10 @@ gboolean builder_unquote(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock 
         return 0;
     }
 
-    return compile_macro_expression(ctx, b, basic_block, err, &unquote, allow_macro, allow_runtime, allow_macro_expansion);
+    return compile_expression(ctx, b, basic_block, err, &unquote, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
 }
 
-gboolean compile_cond_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean compile_cond_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     switch ((*stmt)->kind) {
     case GTKML_S_FALSE:
     case GTKML_S_TRUE:
@@ -2886,7 +3043,7 @@ gboolean compile_cond_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_Bas
         return gtk_ml_build_setf_extended_imm(ctx, b, *basic_block, err, gtk_ml_append_static(b, new_true(ctx, &(*stmt)->span)));
     case GTKML_S_LIST:
     case GTKML_S_SYMBOL:
-        if (!compile_macro_expression(ctx, b, basic_block, err, stmt, allow_macro, allow_runtime, allow_macro_expansion)) {
+        if (!compile_expression(ctx, b, basic_block, err, stmt, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
             return 0;
         }
         return gtk_ml_build_popf(ctx, b, *basic_block, err);
@@ -2897,13 +3054,13 @@ gboolean compile_cond_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_Bas
         if ((*stmt)->value.s_quote.expr->kind == GTKML_S_SYMBOL || (*stmt)->value.s_quote.expr->kind == GTKML_S_LIST) {
             return gtk_ml_build_setf_extended_imm(ctx, b, *basic_block, err, gtk_ml_append_static(b, new_true(ctx, &(*stmt)->span)));
         } else {
-            return compile_cond_expression(ctx, b, basic_block, err, &(*stmt)->value.s_quote.expr, allow_macro, allow_runtime, allow_macro_expansion);
+            return compile_cond_expression(ctx, b, basic_block, err, &(*stmt)->value.s_quote.expr, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
         }
     case GTKML_S_QUASIQUOTE:
         if ((*stmt)->value.s_quote.expr->kind == GTKML_S_SYMBOL || (*stmt)->value.s_quote.expr->kind == GTKML_S_LIST) {
             return gtk_ml_build_setf_extended_imm(ctx, b, *basic_block, err, gtk_ml_append_static(b, new_true(ctx, &(*stmt)->span)));
         } else {
-            return compile_cond_expression(ctx, b, basic_block, err, &(*stmt)->value.s_quote.expr, allow_macro, allow_runtime, allow_macro_expansion);
+            return compile_cond_expression(ctx, b, basic_block, err, &(*stmt)->value.s_quote.expr, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
         }
     case GTKML_S_UNQUOTE:
         *err = gtk_ml_error(ctx, "unquote-error", GTKML_ERR_UNQUOTE_ERROR, (*stmt)->span.ptr != NULL, (*stmt)->span.line, (*stmt)->span.col, 0);
@@ -2921,7 +3078,7 @@ gboolean compile_std_call(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock
         ++n;
     }
     while (args->kind != GTKML_S_NIL) {
-        if (!compile_expression(ctx, b, basic_block, err, &gtk_ml_car(args))) {
+        if (!compile_runtime_expression(ctx, b, basic_block, err, &gtk_ml_car(args))) {
             return 0;
         }
         args = gtk_ml_cdr(args);
@@ -2944,6 +3101,7 @@ struct CompileData {
     GtkMl_BasicBlock **basic_block;
     GtkMl_S **err;
     GtkMl_S *stmt;
+    gboolean allow_intr;
     gboolean allow_macro;
     gboolean allow_runtime;
     gboolean allow_macro_expansion;
@@ -2954,11 +3112,11 @@ GTKML_PRIVATE GtkMl_VisitResult compile_quasi_map(GtkMl_HashTrie *ht, void *key,
     (void) ht;
 
     struct CompileData *data = _data;
-    if (!compile_macro_quasi_expression(data->ctx, data->b, data->basic_block, data->err, key, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
+    if (!compile_quasi_expression(data->ctx, data->b, data->basic_block, data->err, key, data->allow_intr, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
         data->result = 0;
         return GTKML_VISIT_BREAK;
     }
-    if (!compile_macro_quasi_expression(data->ctx, data->b, data->basic_block, data->err, value, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
+    if (!compile_quasi_expression(data->ctx, data->b, data->basic_block, data->err, value, data->allow_intr, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
         data->result = 0;
         return GTKML_VISIT_BREAK;
     }
@@ -2969,7 +3127,7 @@ GTKML_PRIVATE GtkMl_VisitResult compile_quasi_set(GtkMl_HashSet *hs, void *key, 
     (void) hs;
 
     struct CompileData *data = _data;
-    if (!compile_macro_quasi_expression(data->ctx, data->b, data->basic_block, data->err, key, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
+    if (!compile_quasi_expression(data->ctx, data->b, data->basic_block, data->err, key, data->allow_intr, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
         data->result = 0;
         return GTKML_VISIT_BREAK;
     }
@@ -2981,7 +3139,7 @@ GTKML_PRIVATE GtkMl_VisitResult compile_quasi_array(GtkMl_Array *array, size_t i
     (void) idx;
 
     struct CompileData *data = _data;
-    if (!compile_macro_quasi_expression(data->ctx, data->b, data->basic_block, data->err, value, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
+    if (!compile_quasi_expression(data->ctx, data->b, data->basic_block, data->err, value, data->allow_intr, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
         data->result = 0;
         return GTKML_VISIT_BREAK;
     }
@@ -2994,11 +3152,11 @@ GTKML_PRIVATE GtkMl_VisitResult compile_map(GtkMl_HashTrie *ht, void *key_ptr, v
     GtkMl_S *value = value_ptr;
 
     struct CompileData *data = _data;
-    if (!compile_macro_expression(data->ctx, data->b, data->basic_block, data->err, &key, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
+    if (!compile_expression(data->ctx, data->b, data->basic_block, data->err, &key, data->allow_intr, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
         data->result = 0;
         return GTKML_VISIT_BREAK;
     }
-    if (!compile_macro_expression(data->ctx, data->b, data->basic_block, data->err, &value, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
+    if (!compile_expression(data->ctx, data->b, data->basic_block, data->err, &value, data->allow_intr, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
         data->result = 0;
         return GTKML_VISIT_BREAK;
     }
@@ -3010,7 +3168,7 @@ GTKML_PRIVATE GtkMl_VisitResult compile_set(GtkMl_HashSet *hs, void *key_ptr, vo
     GtkMl_S *key = key_ptr;
 
     struct CompileData *data = _data;
-    if (!compile_macro_expression(data->ctx, data->b, data->basic_block, data->err, &key, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
+    if (!compile_expression(data->ctx, data->b, data->basic_block, data->err, &key, data->allow_intr, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
         data->result = 0;
         return GTKML_VISIT_BREAK;
     }
@@ -3022,22 +3180,22 @@ GTKML_PRIVATE GtkMl_VisitResult compile_array(GtkMl_Array *array, size_t idx, Gt
     (void) idx;
 
     struct CompileData *data = _data;
-    if (!compile_macro_expression(data->ctx, data->b, data->basic_block, data->err, &value, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
+    if (!compile_expression(data->ctx, data->b, data->basic_block, data->err, &value, data->allow_intr, data->allow_macro, data->allow_runtime, data->allow_macro_expansion)) {
         data->result = 0;
         return GTKML_VISIT_BREAK;
     }
     return GTKML_VISIT_RECURSE;
 }
 
-gboolean compile_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt) {
-    return compile_macro_expression(ctx, b, basic_block, err, stmt, 0, 1, 1);
+gboolean compile_runtime_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt) {
+    return compile_expression(ctx, b, basic_block, err, stmt, 0, 0, 1, 1);
 }
 
-gboolean compile_program(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, const char *linkage_name, GtkMl_S *lambda, gboolean ret) {
-    return compile_macro_program(ctx, b, basic_block, err, linkage_name, lambda, ret, 0, 1, 1);
+gboolean compile_runtime_program(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, const char *linkage_name, GtkMl_S *lambda, gboolean ret) {
+    return compile_program(ctx, b, basic_block, err, linkage_name, lambda, ret, 0, 0, 1, 1);
 }
 
-gboolean compile_macro_quasi_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S *stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean compile_quasi_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S *stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     switch (stmt->kind) {
     case GTKML_S_NIL:
     case GTKML_S_TRUE:
@@ -3060,24 +3218,24 @@ gboolean compile_macro_quasi_expression(GtkMl_Context *ctx, GtkMl_Builder *b, Gt
         return gtk_ml_build_push_extended_imm(ctx, b, *basic_block, err, gtk_ml_append_static(b, stmt));
     case GTKML_S_MAP: {
         int64_t n = gtk_ml_hash_trie_len(&stmt->value.s_map.map);
-        struct CompileData data = { ctx, b, basic_block, err, stmt, allow_macro, allow_runtime, allow_macro_expansion, 1 }; 
+        struct CompileData data = { ctx, b, basic_block, err, stmt, allow_intr, allow_macro, allow_runtime, allow_macro_expansion, 1 }; 
         gtk_ml_hash_trie_foreach(&stmt->value.s_map.map, compile_quasi_map, &data);
         return gtk_ml_build_map_extended_imm(ctx, b, *basic_block, err, gtk_ml_append_static(b, new_int(ctx, NULL, n)));
     }
     case GTKML_S_SET: {
         int64_t n = gtk_ml_hash_set_len(&stmt->value.s_set.set);
-        struct CompileData data = { ctx, b, basic_block, err, stmt, allow_macro, allow_runtime, allow_macro_expansion, 1 }; 
+        struct CompileData data = { ctx, b, basic_block, err, stmt, allow_intr, allow_macro, allow_runtime, allow_macro_expansion, 1 }; 
         gtk_ml_hash_set_foreach(&stmt->value.s_set.set, compile_quasi_set, &data);
         return gtk_ml_build_set_extended_imm(ctx, b, *basic_block, err, gtk_ml_append_static(b, new_int(ctx, NULL, n)));
     }
     case GTKML_S_ARRAY: {
         int64_t n = gtk_ml_array_len(&stmt->value.s_array.array);
-        struct CompileData data = { ctx, b, basic_block, err, stmt, allow_macro, allow_runtime, allow_macro_expansion, 1 }; 
+        struct CompileData data = { ctx, b, basic_block, err, stmt, allow_intr, allow_macro, allow_runtime, allow_macro_expansion, 1 }; 
         gtk_ml_array_foreach(&stmt->value.s_array.array, compile_quasi_array, &data);
         return gtk_ml_build_array_extended_imm(ctx, b, *basic_block, err, gtk_ml_append_static(b, new_int(ctx, NULL, n)));
     }
     case GTKML_S_UNQUOTE:
-        return compile_macro_expression(ctx, b, basic_block, err, &stmt->value.s_unquote.expr, allow_macro, allow_runtime, allow_macro_expansion);
+        return compile_expression(ctx, b, basic_block, err, &stmt->value.s_unquote.expr, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
     case GTKML_S_LIST: {
         GtkMl_S *function = gtk_ml_car(stmt);
 
@@ -3093,13 +3251,13 @@ gboolean compile_macro_quasi_expression(GtkMl_Context *ctx, GtkMl_Builder *b, Gt
                     return 0;
                 }
 
-                return compile_macro_expression(ctx, b, basic_block, err, &gtk_ml_car(args), allow_macro, allow_runtime, allow_macro_expansion);
+                return compile_expression(ctx, b, basic_block, err, &gtk_ml_car(args), allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
             }
         }
 
         int64_t n = 0;
         while (stmt->kind != GTKML_S_NIL) {
-            if (!compile_macro_quasi_expression(ctx, b, basic_block, err, gtk_ml_car(stmt), allow_macro, allow_runtime, allow_macro_expansion)) {
+            if (!compile_quasi_expression(ctx, b, basic_block, err, gtk_ml_car(stmt), allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
                 return 0;
             }
             stmt = gtk_ml_cdr(stmt);
@@ -3110,7 +3268,7 @@ gboolean compile_macro_quasi_expression(GtkMl_Context *ctx, GtkMl_Builder *b, Gt
     }
 }
 
-gboolean compile_macro_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean compile_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S **stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     switch ((*stmt)->kind) {
     case GTKML_S_NIL:
     case GTKML_S_TRUE:
@@ -3130,7 +3288,7 @@ gboolean compile_macro_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_Ba
         char *linkage_name = malloc(strlen("lambda$") + 16);
         snprintf(linkage_name, strlen("lambda$") + 16, "lambda$%u", b->counter++);
         GtkMl_BasicBlock *bb = gtk_ml_append_basic_block(b, linkage_name);
-        if (!compile_macro_program(ctx, b, &bb, err, linkage_name, *stmt, 1, allow_macro, allow_runtime, allow_macro_expansion)) {
+        if (!compile_program(ctx, b, &bb, err, linkage_name, *stmt, 1, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
             return 0;
         }
         return gtk_ml_build_push_extended_addr(ctx, b, *basic_block, err, gtk_ml_append_static(b, new_string(ctx, NULL, linkage_name, strlen(linkage_name))));
@@ -3139,31 +3297,31 @@ gboolean compile_macro_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_Ba
         char *linkage_name = malloc(strlen("macro$") + 16);
         snprintf(linkage_name, strlen("macro$") + 16, "macro$%u", b->counter++);
         GtkMl_BasicBlock *bb = gtk_ml_append_basic_block(b, linkage_name);
-        if (!compile_macro_program(ctx, b, &bb, err, linkage_name, *stmt, 1, allow_macro, allow_runtime, allow_macro_expansion)) {
+        if (!compile_program(ctx, b, &bb, err, linkage_name, *stmt, 1, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
             return 0;
         }
         return gtk_ml_build_push_extended_addr(ctx, b, *basic_block, err, gtk_ml_append_static(b, new_string(ctx, NULL, linkage_name, strlen(linkage_name))));
     }
     case GTKML_S_MAP: {
         int64_t n = gtk_ml_hash_trie_len(&(*stmt)->value.s_map.map);
-        struct CompileData data = { ctx, b, basic_block, err, (*stmt), allow_macro, allow_runtime, allow_macro_expansion, 1 }; 
+        struct CompileData data = { ctx, b, basic_block, err, (*stmt), allow_intr, allow_macro, allow_runtime, allow_macro_expansion, 1 }; 
         gtk_ml_hash_trie_foreach(&(*stmt)->value.s_map.map, compile_map, &data);
         return gtk_ml_build_map_extended_imm(ctx, b, *basic_block, err, gtk_ml_append_static(b, new_int(ctx, NULL, n)));
     }
     case GTKML_S_SET: {
         int64_t n = gtk_ml_hash_set_len(&(*stmt)->value.s_set.set);
-        struct CompileData data = { ctx, b, basic_block, err, (*stmt), allow_macro, allow_runtime, allow_macro_expansion, 1 }; 
+        struct CompileData data = { ctx, b, basic_block, err, (*stmt), allow_intr, allow_macro, allow_runtime, allow_macro_expansion, 1 }; 
         gtk_ml_hash_set_foreach(&(*stmt)->value.s_set.set, compile_set, &data);
         return gtk_ml_build_set_extended_imm(ctx, b, *basic_block, err, gtk_ml_append_static(b, new_int(ctx, NULL, n)));
     }
     case GTKML_S_ARRAY: {
         int64_t n = gtk_ml_array_len(&(*stmt)->value.s_array.array);
-        struct CompileData data = { ctx, b, basic_block, err, (*stmt), allow_macro, allow_runtime, allow_macro_expansion, 1 }; 
+        struct CompileData data = { ctx, b, basic_block, err, (*stmt), allow_intr, allow_macro, allow_runtime, allow_macro_expansion, 1 }; 
         gtk_ml_array_foreach(&(*stmt)->value.s_array.array, compile_array, &data);
         return gtk_ml_build_array_extended_imm(ctx, b, *basic_block, err, gtk_ml_append_static(b, new_int(ctx, NULL, n)));
     }
     case GTKML_S_VAR:
-        compile_macro_expression(ctx, b, basic_block, err, &(*stmt)->value.s_var.expr, allow_macro, allow_runtime, allow_macro_expansion);
+        compile_expression(ctx, b, basic_block, err, &(*stmt)->value.s_var.expr, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
         return gtk_ml_build_var_imm(ctx, b, *basic_block, err);
     case GTKML_S_VARARG:
         *err = gtk_ml_error(ctx, "unimplemented", GTKML_ERR_UNIMPLEMENTED, (*stmt)->span.ptr != NULL, (*stmt)->span.line, (*stmt)->span.col, 0);
@@ -3171,7 +3329,7 @@ gboolean compile_macro_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_Ba
     case GTKML_S_QUOTE:
         return gtk_ml_build_push_extended_imm(ctx, b, *basic_block, err, gtk_ml_append_static(b, (*stmt)->value.s_quote.expr));
     case GTKML_S_QUASIQUOTE:
-        return compile_macro_quasi_expression(ctx, b, basic_block, err, (*stmt)->value.s_quasiquote.expr, allow_macro, allow_runtime, allow_macro_expansion);
+        return compile_quasi_expression(ctx, b, basic_block, err, (*stmt)->value.s_quasiquote.expr, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
     case GTKML_S_UNQUOTE:
         *err = gtk_ml_error(ctx, "unquote-error", GTKML_ERR_UNQUOTE_ERROR, (*stmt)->span.ptr != NULL, (*stmt)->span.line, (*stmt)->span.col, 0);
         return 0;
@@ -3186,18 +3344,39 @@ gboolean compile_macro_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_Ba
             for (size_t i = 0; i < b->len_builder; i++) {
                 GtkMl_BuilderMacro *bm = b->builders + i;
                 if (strlen(bm->name) == len && strncmp(bm->name, ptr, len) == 0) {
-                    if (bm->require_macro) {
+                    if (bm->require_intrinsic) {
+                        if (allow_intr) {
+                            return bm->fn(ctx, b, basic_block, err, stmt, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
+                        }
+                    } else if (bm->require_macro) {
                         if (allow_macro) {
-                            return bm->fn(ctx, b, basic_block, err, stmt, allow_macro, allow_runtime, allow_macro_expansion);
+                            return bm->fn(ctx, b, basic_block, err, stmt, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
                         }
                     } else if (bm->require_runtime) {
                         if (allow_runtime) {
-                            return bm->fn(ctx, b, basic_block, err, stmt, allow_macro, allow_runtime, allow_macro_expansion);
+                            return bm->fn(ctx, b, basic_block, err, stmt, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
                         }
                     } else {
-                        return bm->fn(ctx, b, basic_block, err, stmt, allow_macro, allow_runtime, allow_macro_expansion);
+                        return bm->fn(ctx, b, basic_block, err, stmt, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
                     }
                 }
+            }
+        }
+
+        if (!allow_intr && (*function)->kind == GTKML_S_SYMBOL) {
+            size_t len = (*function)->value.s_symbol.len;
+            char *linkage_name = malloc(len + 1);
+            memcpy(linkage_name, (*function)->value.s_symbol.ptr, len);
+            linkage_name[len] = 0;
+
+            GtkMl_S *_err = NULL;
+            GtkMl_S *program = gtk_ml_get_export(b->intr_ctx, &_err, linkage_name);
+            free(linkage_name);
+            if (program) {
+                gtk_ml_define(b->intr_ctx, new_symbol(ctx, NULL, 0, "CTX", strlen("CTX")), new_lightdata(ctx, NULL, ctx));
+                gtk_ml_define(b->intr_ctx, new_symbol(ctx, NULL, 0, "CODE-BUILDER", strlen("CODE-BUILDER")), new_lightdata(ctx, NULL, b));
+                gtk_ml_define(b->intr_ctx, new_symbol(ctx, NULL, 0, "BASIC-BLOCK", strlen("BASIC-BLOCK")), new_lightdata(ctx, NULL, basic_block));
+                return gtk_ml_run_program(b->intr_ctx, err, program, args);
             }
         }
 
@@ -3223,14 +3402,14 @@ gboolean compile_macro_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_Ba
 
                 *stmt = result;
 
-                return compile_macro_expression(ctx, b, basic_block, err, stmt, allow_macro, allow_runtime, allow_macro_expansion);
+                return compile_expression(ctx, b, basic_block, err, stmt, allow_intr, allow_macro, allow_runtime, allow_macro_expansion);
             }
         }
 
         int64_t n_args = 0;
         while (args->kind != GTKML_S_NIL) {
             GtkMl_S **arg = &gtk_ml_car(args);
-            if (!compile_macro_expression(ctx, b, basic_block, err, arg, allow_macro, allow_runtime, allow_macro_expansion)) {
+            if (!compile_expression(ctx, b, basic_block, err, arg, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
                 return 0;
             }
             ++n_args;
@@ -3241,7 +3420,7 @@ gboolean compile_macro_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_Ba
             return 0;
         }
 
-        if (!compile_macro_expression(ctx, b, basic_block, err, function, allow_macro, allow_runtime, allow_macro_expansion)) {
+        if (!compile_expression(ctx, b, basic_block, err, function, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
             return 0;
         }
 
@@ -3250,10 +3429,10 @@ gboolean compile_macro_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_Ba
     }
 }
 
-gboolean compile_macro_body(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S *body, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean compile_body(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, GtkMl_S *body, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     while (body->kind != GTKML_S_NIL) {
         GtkMl_S **stmt = &gtk_ml_car(body);
-        if (!compile_macro_expression(ctx, b, basic_block, err, stmt, allow_macro, allow_runtime, allow_macro_expansion)) {
+        if (!compile_expression(ctx, b, basic_block, err, stmt, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
             return 0;
         }
         body = gtk_ml_cdr(body);
@@ -3262,7 +3441,7 @@ gboolean compile_macro_body(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlo
     return 1;
 }
 
-gboolean compile_macro_program(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, const char *linkage_name, GtkMl_S *lambda, gboolean ret, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
+gboolean compile_program(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_S **err, const char *linkage_name, GtkMl_S *lambda, gboolean ret, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) {
     if ((!allow_macro || lambda->kind != GTKML_S_MACRO) && lambda->kind != GTKML_S_LAMBDA) {
         *err = gtk_ml_error(ctx, "program-error", GTKML_ERR_PROGRAM_ERROR, lambda->span.ptr != NULL, lambda->span.line, lambda->span.col, 0);
         return 0;
@@ -3304,7 +3483,7 @@ gboolean compile_macro_program(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_Basic
         return 0;
     }
 
-    if (!compile_macro_body(ctx, b, basic_block, err, lambda->value.s_lambda.body, allow_macro, allow_runtime, allow_macro_expansion)) {
+    if (!compile_body(ctx, b, basic_block, err, lambda->value.s_lambda.body, allow_intr, allow_macro, allow_runtime, allow_macro_expansion)) {
         return 0;
     }
 
@@ -4192,6 +4371,52 @@ gboolean gtk_ml_build_bitxor(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBl
     return 1;
 }
 
+gboolean gtk_ml_compile_intrinsics(GtkMl_Builder *b, GtkMl_S **err, GtkMl_S *lambda) {
+    GtkMl_S *prev = lambda->value.s_lambda.body;
+    GtkMl_S *next = prev;
+    while (next->kind != GTKML_S_NIL) {
+        GtkMl_S *stmt = gtk_ml_car(next);
+
+        GtkMl_S *function = gtk_ml_car(stmt);
+
+        GtkMl_S *args = gtk_ml_cdr(stmt);
+
+        if (function->kind == GTKML_S_SYMBOL) {
+            const char *symbol_define_intrinsic = "define-intrinsic";
+
+            if (function->value.s_symbol.len == strlen(symbol_define_intrinsic)
+                    && memcmp(function->value.s_symbol.ptr, symbol_define_intrinsic, function->value.s_symbol.len) == 0) {
+                GtkMl_S *intrinsic_definition = gtk_ml_car(args);
+                GtkMl_S *intrinsic_name = gtk_ml_car(intrinsic_definition);
+                GtkMl_S *intrinsic_args = gtk_ml_cdr(intrinsic_definition);
+                GtkMl_S *intrinsic_body = gtk_ml_cdr(args);
+
+                GtkMl_S *intrinsic = new_lambda(b->intr_ctx, NULL, intrinsic_args, intrinsic_body, local_scope(b->intr_ctx));
+                if (!intrinsic) {
+                    return 0;
+                }
+
+                size_t len = intrinsic_name->value.s_symbol.len;
+                char *linkage_name = malloc(len + 1);
+                memcpy(linkage_name, intrinsic_name->value.s_symbol.ptr, len);
+                linkage_name[len] = 0;
+
+                GtkMl_BasicBlock *basic_block = gtk_ml_append_basic_block(b, linkage_name);
+
+                if (!compile_program(b->intr_ctx, b, &basic_block, err, linkage_name, intrinsic, 1, 1, 0, 0, 0)) {
+                    free(linkage_name);
+                    return 0;
+                }
+
+                free(linkage_name);
+            }
+        }
+        next = gtk_ml_cdr(next);
+    }
+    
+    return 1;
+}
+
 gboolean gtk_ml_compile_macros(GtkMl_Builder *b, GtkMl_S **err, GtkMl_S *lambda) {
     GtkMl_S *prev = lambda->value.s_lambda.body;
     GtkMl_S *next = prev;
@@ -4224,7 +4449,7 @@ gboolean gtk_ml_compile_macros(GtkMl_Builder *b, GtkMl_S **err, GtkMl_S *lambda)
 
                 GtkMl_BasicBlock *basic_block = gtk_ml_append_basic_block(b, linkage_name);
 
-                if (!compile_macro_program(b->macro_ctx, b, &basic_block, err, linkage_name, macro, 1, 1, 0, 0)) {
+                if (!compile_program(b->macro_ctx, b, &basic_block, err, linkage_name, macro, 1, 0, 1, 0, 0)) {
                     free(linkage_name);
                     return 0;
                 }
@@ -4242,7 +4467,7 @@ gboolean gtk_ml_compile(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S **err, Gtk
     const char *linkage_name = "_start";
     GtkMl_BasicBlock *basic_block = gtk_ml_append_basic_block(b, linkage_name);
 
-    if (!compile_program(ctx, b, &basic_block, err, linkage_name, lambda, 0)) {
+    if (!compile_runtime_program(ctx, b, &basic_block, err, linkage_name, lambda, 0)) {
         return 0;
     }
 
@@ -4254,6 +4479,16 @@ gboolean gtk_ml_compile(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S **err, Gtk
 }
 
 gboolean gtk_ml_compile_program(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S **err, GtkMl_S *lambda) {
+    if (!gtk_ml_compile_intrinsics(b, err, lambda)) {
+        return 0;
+    }
+    GtkMl_Program intrinsics;
+    if (!gtk_ml_build_intrinsics(&intrinsics, err, b)) {
+        return 0;
+    }
+    gtk_ml_load_program(b->intr_ctx, &intrinsics);
+    gtk_ml_del_program(&intrinsics);
+
     if (!gtk_ml_compile_macros(b, err, lambda)) {
         return 0;
     }
@@ -4263,6 +4498,7 @@ gboolean gtk_ml_compile_program(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_S **
     }
     gtk_ml_load_program(b->macro_ctx, &macros);
     gtk_ml_del_program(&macros);
+
     return gtk_ml_compile(ctx, b, err, lambda);
 }
 
@@ -4996,6 +5232,38 @@ GTKML_PRIVATE GtkMl_S *vm_std_error(GtkMl_Context *ctx, GtkMl_S **err, GtkMl_S *
     *err = error_expr;
 
     return NULL;
+}
+
+GTKML_PRIVATE GtkMl_S *vm_std_compile_expr(GtkMl_Context *ctx, GtkMl_S **err, GtkMl_S *expr) {
+    (void) expr;
+    GtkMl_S *arg = gtk_ml_pop(ctx);
+    GtkMl_BasicBlock **arg_basic_block = gtk_ml_pop(ctx)->value.s_lightdata.userdata;
+    GtkMl_Builder *arg_b = gtk_ml_pop(ctx)->value.s_lightdata.userdata;
+    GtkMl_Context *arg_ctx = gtk_ml_pop(ctx)->value.s_lightdata.userdata;
+
+    return compile_expression(arg_ctx, arg_b, arg_basic_block, err, &arg, 0, 0, 1, 1)? new_true(ctx, NULL) : NULL;
+}
+
+GTKML_PRIVATE GtkMl_S *vm_std_emit_bytecode(GtkMl_Context *ctx, GtkMl_S **err, GtkMl_S *expr) {
+    (void) expr;
+
+    GtkMl_S *bc = gtk_ml_pop(ctx);
+    unsigned int arg_cond = gtk_ml_pop(ctx)->value.s_int.value;
+    GtkMl_BasicBlock **arg_basic_block = gtk_ml_pop(ctx)->value.s_lightdata.userdata;
+    GtkMl_Builder *arg_b = gtk_ml_pop(ctx)->value.s_lightdata.userdata;
+    GtkMl_Context *arg_ctx = gtk_ml_pop(ctx)->value.s_lightdata.userdata;
+    const char *bc_ptr = bc->value.s_keyword.ptr;
+    size_t bc_len = bc->value.s_keyword.len;
+
+    const char *bc_add = "add";
+
+    if (strlen(bc_add) == bc_len && strncmp(bc_ptr, bc_add, bc_len) == 0) {
+        gtk_ml_builder_set_cond(arg_b, arg_cond);
+        return gtk_ml_build_add(arg_ctx, arg_b, *arg_basic_block, err)? new_true(ctx, NULL) : NULL;
+    } else {
+        *err = gtk_ml_error(ctx, "bytecode-error", GTKML_ERR_BYTECODE_ERROR, bc->span.ptr != NULL, bc->span.line, bc->span.col, 0);
+        return NULL;
+    }
 }
 
 gboolean gtk_ml_equal(GtkMl_S *lhs, GtkMl_S *rhs) {
@@ -6270,14 +6538,6 @@ gboolean gtk_ml_eii_cmp_ext_imm(GtkMl_Vm *vm, GtkMl_S **err, GtkMl_Instruction i
 
     GtkMl_S *lhs = gtk_ml_pop(vm->ctx);
     GtkMl_S *rhs = gtk_ml_pop(vm->ctx);
-
-    printf("(cmp ");
-    gtk_ml_dumpf(vm->ctx, stdout, NULL, imm64);
-    printf(" ");
-    gtk_ml_dumpf(vm->ctx, stdout, NULL, lhs);
-    printf(" ");
-    gtk_ml_dumpf(vm->ctx, stdout, NULL, rhs);
-    printf(")\n");
 
     switch (cmp) {
     case GTKML_CMP_EQUAL:


### PR DESCRIPTION
This pull request implements new bytecodes and a couple corresponding special forms.

New bytecodes:

- `len`
- `array-index`
- `array-push`
- `array-pop`
- `map-get`
- `map-insert`
- `map-delete`
- `set-contains`
- `set-insert`
- `set-delete`
- `car`
- `cdr`
- `enter`
- `leave`
- `typeof`

New special forms:

```clojure
(len container) ; -> :int
(index array) ; -> :any
(push array element) ; -> :array
(pop array) ; -> :array
(car list) ; -> :any
(cdr list) ; -> :list or :nil
(typeof expr) ; -> :keyword
```

Also a couple fixes and improvement where implemented.