### PR TITLE
Feature: variadic arguments

### DIFF
--- a/examples/hello.gtkml
+++ b/examples/hello.gtkml
@@ -11,6 +11,7 @@
 
 ; returns true if expression is a non-empty list
 (define (list? expr) (= (typeof expr) :list))
+(define (nil? expr) (= (typeof expr) :nil))
 
 ; returns true if expression is a constant number or an expression that evaluates to a constant number
 (define (const-number? expr)
@@ -45,6 +46,14 @@
       (compile-expr CTX CODE-BUILDER BASIC-BLOCK a)
       (emit-bytecode CTX CODE-BUILDER BASIC-BLOCK cond-none :add))))
 
+(define (sum-v a rest)
+  (cond
+    (nil? rest) a
+    :else       (+ a (sum-v (car rest) (cdr rest)))))
+
+(define (sum a ...rest)
+  (sum-v a rest))
+
 ; define a Window macro
 (define-macro (Window title width height)
   `(lambda (app)
@@ -57,5 +66,5 @@
     (cond
       #f          (error {:err 'cond-error :desc "cond evaluated in an incorrect way"})
       (cmp 0 1 2) (error {:err 'cond-error :desc "cond evaluated in an incorrect way"})
-      :else       640)
+      :else       (sum 160 160 160 160))
     (do 0 (intr-add 240 240)))})

--- a/examples/hello.gtkml
+++ b/examples/hello.gtkml
@@ -46,25 +46,26 @@
       (compile-expr CTX CODE-BUILDER BASIC-BLOCK a)
       (emit-bytecode CTX CODE-BUILDER BASIC-BLOCK cond-none :add))))
 
-(define (sum-v a rest)
+(define (sum a ...rest)
   (cond
     (nil? rest) a
-    :else       (+ a (sum-v (car rest) (cdr rest)))))
-
-(define (sum a ...rest)
-  (sum-v a rest))
+    :else       (+ a (sum (car rest) ...(cdr rest)))))
 
 ; define a Window macro
-(define-macro (Window title width height)
+(define-macro (Window title width height ...body)
   `(lambda (app)
-    (new-window app ,title ,width ,height)))
+    (new-window app ,title ,width ,height)
+    ,...body))
 
 ; run the application
 (Application "de.walterpi.example" flags-none {
   :activate (Window
+    ;; title
     "gtk-ml example"
+    ;; width
     (cond
       #f          (error {:err 'cond-error :desc "cond evaluated in an incorrect way"})
       (cmp 0 1 2) (error {:err 'cond-error :desc "cond evaluated in an incorrect way"})
       :else       (sum 160 160 160 160))
+    ;; height
     (do 0 (intr-add 240 240)))})

--- a/examples/match.gtkml
+++ b/examples/match.gtkml
@@ -1,0 +1,167 @@
+(match '(1 2 3)
+  (cons _ (cons x _)) x
+  :else               #nil)
+
+(let-match [(cons a _) (list 1 2 3)]
+  a)
+
+(define (= a b) (cmp 0 a b))
+
+(define (get-and-inc v)
+  (let [value @v]
+    (assign v (+ @v 1))
+    value))
+
+(define (empty? container) (= (len container) 0))
+(define (nil? list) (= (typeof list) :list))
+
+(define (format-v-impl acc offset fmt args)
+  (cond
+    (empty? fmt) (cond
+      (nil? args) acc
+      :else       (error '{:err arity-error :desc "too many format arguments"}))
+    :else (cond
+      (= (index fmt offset) \~) (cond
+        (= (index fmt (+ offset 1)) \a) (cond
+          (nil? args) (error '{:err arity-error :desc "too few format arguments"})
+          :else       (format-v-impl (concat acc (car args)) (+ offset 1) fmt  (cdr args))
+        :else                           (error '{:err fmt-error :desc "invalid format string" :char (index fmt (+ offset 1))}))
+      (= (index fmt (+ offset 1)) \d) (cond
+          (nil? args) (error '{:err arity-error :desc "too few format arguments"})
+          :else       (format-v-impl (concat acc (signed->string (car args))) (+ offset 1) fmt  (cdr args))
+        :else                           (error '{:err fmt-error :desc "invalid format string" :char (index fmt (+ offset 1))}))
+      (= (index fmt (+ offset 1)) \u) (cond
+          (nil? args) (error '{:err arity-error :desc "too few format arguments"})
+          :else       (format-v-impl (concat acc (unsigned->string (car args))) (+ offset 1) fmt  (cdr args))
+        :else                           (error '{:err fmt-error :desc "invalid format string" :char (index fmt (+ offset 1))}))
+      :else                     (format-v-impl (push acc (index fmt offset) (+ offset 1) fmt args)))))
+
+(define (format-v fmt args)
+  (format-v-impl "" 0 fmt args))
+
+(define (format fmt ...args) (format-v fmt args)
+
+(define-intrinsic (let-impl bindings body)
+  (if (empty? bindings)
+    (compile-expr CTX CODE-BUILDER BASIC-BLOCK `(do ,...body))
+    (do
+      (cond
+        (= (len bindings) 1) (error '{:err arity-eror :desc "let requires an even count of key-value pairs"})
+        :else                #nil)
+      (compile-expr CTX CODE-BUILDER BASIC-BLOCK (reverse-index bindings 1))
+      (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :push-imm (reverse-index bindings 2))
+      (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :bind)
+      (intr-let-impl (pop (pop bindings)) body))))
+
+(define-intrinsic (let bindings ...body)
+  (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :enter)
+  (intr-let-impl bindings body)
+  (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :leave))
+
+(define-intrinsic (let*-impl offset bindings body)
+  (if (= (len bindings) offset)
+    (compile-expr CTX CODE-BUILDER BASIC-BLOCK `(do ,...body))
+    (do
+      (cond
+        (= (len bindings) (+ offset 1)) (error '{:err arity-eror :desc "let* requires an even count of key-value pairs"})
+        :else                #nil)
+      (compile-expr CTX CODE-BUILDER BASIC-BLOCK (index bindings (+ offset 1)))
+      (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :push-imm (index bindings offset))
+      (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :bind)
+      (intr-let-impl (+ offset 2) bindings body))))
+
+(define-intrinsic (let* bindings ...body)
+  (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :enter)
+  (intr-let-impl bindings body)
+  (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :leave))
+
+;; this assumes that format is implemented
+(define (gensym name)
+  (symbol (format "~a$~d" name (get-and-inc (global-counter CODE-BUILDER)))))
+
+(define-intrinsic (compile-pattern ctx code-builder basic-block pattern no cnt sym-value)
+  (cond
+    (= pat :else) (intr-apply let* [else (format "match$~d$else" no)
+                                    bb   (append-basic-block CODE-BUILDER else)]
+      (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :push-imm #t)
+      [else bb])
+    (= pat '_) (intr-apply let* [else (format "match$~d$wildcard" no)
+                                 bb   (append-basic-block CODE-BUILDER else)]
+      (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :push-imm #t)
+      [else bb])
+    (= (typeof pat) :int) (intr-apply let* [br-name (format "match$~d$~d" no (get-and-inc cnt))
+                                            bb      (append-basic-block CODE-BUILDER br-name)]
+      (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :push-imm pat)
+      (compile-expr CTX CODE-BUILDER BASIC-BLOCK sym-value)
+      (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :cmp 0)
+      [br-name bb])
+    (= (typeof pat) :symbol) (intr-apply let* [br-name (format "match$~d$~d" no (get-and-inc cnt))
+                                               bb      (append-basic-block CODE-BUILDER br-name)]
+      (compile-expr CTX CODE-BUILDER BASIC-BLOCK sym-value)
+      (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :push-imm pat)
+      (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :bind)
+      (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :push-imm #t)
+      [br-name bb])
+    (= (typeof pat) :list) (intr-apply let [decons (car pat)]
+      (cond
+        (= decons 'cons) (intr-apply let [sym-car   (gensym "car")
+                                          sym-cdr   (gensym "cdr")
+                                          pat-car   (cdar pat)
+                                          pat-cdr   (cddar pat)
+                                          br-name   (format "match$~d$~d" no (get-and-inc cnt))
+                                          and-name  (format "match$~d$~d" no (get-and-inc cnt))
+                                          cont-name (format "match$~d$~d" no (get-and-inc cnt))
+                                          bb        (append-basic-block CODE-BUILDER br-name)
+                                          and-bb    (var (append-basic-block CODE-BUILDER and-name))
+                                          cont-bb   (append-basic-block CODE-BUILDER cont-name)]
+          (compile-expr CTX CODE-BUILDER BASIC-BLOCK sym-value)
+          (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :car)
+          (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :push-imm sym-car)
+          (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :bind)
+          (compile-expr CTX CODE-BUILDER BASIC-BLOCK sym-value)
+          (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :cdr)
+          (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :push-imm sym-cdr)
+          (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :bind)
+          (compile-pattern CTX CODE-BUILDER BASIC-BLOCK pat-car no cnt sym-car)
+          (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :popf)
+          (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-eq :branch-absolute and-name)
+          (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :branch-absolute cont-name)
+          (compile-pattern CTX CODE-BUILDER and-bb pat-cdr no cnt sym-cdr)
+          (assign BASIC-BLOCK cont-bb)
+          (emit-bytecode CTX CODE-BUILDER @and-bb cond-none :branch-absolute @BASIC-BLOCK)
+          [br-name bb])
+        :else (error '{:err match-error :desc "unsupported deconstructor"})))
+    :else (error {:err 'match-error :desc "unsupported pattern type" :type (typeof pat)})))
+
+;; this assumes that format and let* are both implemented
+(define-intrinsic (match-impl no cnt end-name sym-value pat branch rest)
+  (intr-apply let* [result  (compile-pattern CTX CODE-BUILDER BASIC-BLOCK pat no cnt sym-value)
+                    br-name (index result 0)
+                    bb      (var (index result 1))]
+    (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-eq :branch-absolute br-name)
+    (compile-expr CTX CODE-BUILDER bb branch)
+    (emit-bytecode CTX CODE-BUILDER @bb cond-none :branch-absolute end-name)
+    (cond
+      (nil? (cdr rest)) (error '{:err arity-error :desc "(match value ...cases) expects an even count of pattern-branch pairs"})
+      :else             (match-impl no cnt end-name sym-value (car rest) (cdar rest) (cddr rest)))))
+
+;; this assumes that format are both implemented
+(define-intrinsic (match value ...cases)
+  (cond
+    (nil? cases) (do
+      (compile-expr CTX CODE-BUILDER BASIC-BLOCK value)
+      (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :pop)
+      (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :push-imm #nil))
+    :else        (cond
+      (nil? (cdr cases)) (error '{:err arity-error :desc "(match value ...cases) expects an even count of pattern-branch pairs"})
+      :else              (intr-apply let [sym-value (gensym "value")
+                                          end-name  (format "match$~d$end" (get-and-inc (global-counter CODE-BUILDER)))
+                                          end       (append-basic-block CODE-BUILDER end-name)
+                                          no        (get-and-inc (global-counter CODE-BUILDER))]
+        (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :enter)
+        (compile-expr CTX CODE-BUILDER BASIC-BLOCK value)
+        (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :push-imm sym-value)
+        (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :bind)
+        (match-impl no (var 0) end-name sym-value (car cases) (cdar cases) (cddr cases))
+        (assign BASIC-BLOCK end)
+        (emit-bytecode CTX CODE-BUILDER @BASIC-BLOCK cond-none :leave)))))

--- a/include/gtk-ml.h
+++ b/include/gtk-ml.h
@@ -84,8 +84,10 @@ typedef enum GtkMl_Cmp {
 #define GTKML_IA_BIND 0x50
 #define GTKML_IA_DEFINE 0x51
 #define GTKML_IA_BIND_ARGS 0x52
+#define GTKML_IA_LIST 0x53
 #define GTKML_IA_ENTER 0x5e
 #define GTKML_IA_LEAVE 0x5f
+#define GTKML_IA_UNWRAP 0x60
 #define GTKML_IA_TYPEOF 0xf0
 
 #define GTKML_II_PUSH_IMM 0x0
@@ -155,9 +157,11 @@ typedef enum GtkMl_Cmp {
 #define GTKML_SIA_BIND "BIND"
 #define GTKML_SIA_DEFINE "DEFINE"
 #define GTKML_SIA_BIND_ARGS "BIND_ARGS"
-#define GTKML_SIA_TYPEOF "TYPEOF"
+#define GTKML_SIA_LIST "LIST"
 #define GTKML_SIA_ENTER "ENTER"
 #define GTKML_SIA_LEAVE "LEAVE"
+#define GTKML_SIA_UNWRAP "UNWRAP"
+#define GTKML_SIA_TYPEOF "TYPEOF"
 
 #define GTKML_SII_PUSH_IMM_EXTERN "PUSH_IMM EXTERN"
 #define GTKML_SII_PUSH_IMM "PUSH_IMM"
@@ -233,6 +237,7 @@ typedef enum GtkMl_Cmp {
 #define GTKML_ERR_BINDING_ERROR "binding not found"
 #define GTKML_ERR_CONSTANT_ERROR "constant not found"
 #define GTKML_ERR_VARARG_ERROR "free-standing vararg expression"
+#define GTKML_ERR_UNWRAP_ERROR "unwrap must be the last expression in an application"
 #define GTKML_ERR_UNQUOTE_ERROR "free-standing unquote expression"
 #define GTKML_ERR_CATEGORY_ERROR "invalid category"
 #define GTKML_ERR_OPCODE_ERROR "invalid opcode"
@@ -688,9 +693,13 @@ GTKML_PUBLIC gboolean gtk_ml_build_bind(GtkMl_Context *ctx, GtkMl_Builder *b, Gt
 // builds a push in the chosen basic_block
 GTKML_PUBLIC gboolean gtk_ml_build_bind_args(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err);
 // builds a push in the chosen basic_block
+GTKML_PUBLIC gboolean gtk_ml_build_list(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err);
+// builds a push in the chosen basic_block
 GTKML_PUBLIC gboolean gtk_ml_build_enter(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err);
 // builds a push in the chosen basic_block
 GTKML_PUBLIC gboolean gtk_ml_build_leave(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err);
+// builds a push in the chosen basic_block
+GTKML_PUBLIC gboolean gtk_ml_build_unwrap(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err);
 // builds a push in the chosen basic_block
 GTKML_PUBLIC gboolean gtk_ml_build_typeof(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_S **err);
 // builds a push in the chosen basic_block

--- a/src/gtk-ml.c
+++ b/src/gtk-ml.c
@@ -627,7 +627,11 @@ gboolean gtk_ml_run_program(GtkMl_Context *ctx, GtkMl_S **err, GtkMl_S *program,
     if (params->kind == GTKML_S_LIST) {
         GtkMl_S *param = gtk_ml_car(params);
         if (param->kind == GTKML_S_VARARG) {
-            gtk_ml_push(ctx, args);
+            while (args->kind != GTKML_S_NIL) {
+                gtk_ml_push(ctx, args);
+                args = gtk_ml_cdr(args);
+                ++n_args;
+            }
         } else {
             *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
             return 0;


### PR DESCRIPTION
This pr re-implements variadic arguments and list unwrapping after they were lost when we moved to bytecode from tree-walking.

```clojure
(define (sum a ...rest)
  (if (nil? rest)
    a
    (+ a (sum ...rest))))
```

List unwrapping can be used in any function application, variadic arguments can be used in intrinsics, macros, runtime functions and lambdas.