### PR TITLE
Feature: modules

### DIFF
--- a/examples/main.gtkml
+++ b/examples/main.gtkml
@@ -1,0 +1,2 @@
+(let [std (load "examples/std.gtkml")]
+  ((map-get std 'foo) 42 54))

--- a/examples/main.gtkml
+++ b/examples/main.gtkml
@@ -1,2 +1,2 @@
 (let [std (load "examples/std.gtkml")]
-  ((map-get std 'foo) 42 54))
+  (.foo std 42 54))

--- a/examples/std.gtkml
+++ b/examples/std.gtkml
@@ -1,0 +1,110 @@
+(define gensym-counter (var 0))
+
+(define (gensym name)
+  (string->symbol (format "~a$~u" name (get-and-inc gensym-counter))))
+
+(define (= a b) (cmp 0 a b))
+(define (> a b) (cmp 3 a b))
+
+(define (get-and-inc v)
+  (let [value @v]
+    (assign v (+ value 1))
+    value))
+
+(define (empty? container) (= (len container) 0))
+(define (nil? list) (= (typeof list) :nil))
+
+(define (reverse-index array ridx) (index array (- (len array) ridx)))
+(define (str-index array idx) (->sobject (index array idx)))
+
+(define (digit->char digit)
+  (cond
+    (= digit 0) \0
+    (= digit 1) \1
+    (= digit 2) \2
+    (= digit 3) \3
+    (= digit 4) \4
+    (= digit 5) \5
+    (= digit 6) \6
+    (= digit 7) \7
+    (= digit 8) \8
+    (= digit 9) \9
+    :else       (error {:err 'digit-error :desc "number is not a digit" :value digit})))
+
+(define (unsigned->string* acc rest digit)
+  (let [acc*   (push acc (->prim (digit->char digit)))
+        rest*  (/ rest 10) ; 0
+        digit* (% rest 10)] ; 1
+    (cond
+      (= rest 0) acc*
+      :else      (unsigned->string* acc* rest* digit*))))
+
+(define (rev-string* acc array)
+  (cond
+    (empty? array) acc
+    :else          (rev-string* (push acc (reverse-index array 1)) (pop array))))
+
+(define (rev-string array)
+  (rev-string* "" array))
+
+(define (unsigned->string num)
+  (rev-string (unsigned->string* "" (/ num 10) (% num 10))))
+
+(define (format-v-impl acc offset fmt args)
+  (cond
+    (= offset (len fmt))
+      (cond
+        (nil? args) acc
+        :else       (error {:err 'arity-error :desc "too many format arguments" :args args}))
+    (> offset (len fmt))
+      (error {:err 'index-out-of-bounds :desc "fmt offset is greater than (len fmt)" :len (len fmt) :offset offset})
+    (= (str-index fmt offset) \~)
+      (cond
+        (= (+ offset 1) (len fmt))
+          (error {:err 'fmt-error :desc "invalid format string" :char (str-index fmt (+ offset 1))})
+        (= (str-index fmt (+ offset 1)) \a)
+          (cond
+            (nil? args) (error '{:err arity-error :desc "too few format arguments"})
+            :else       (format-v-impl (concat acc (car args)) (+ offset 2) fmt (cdr args)))
+        (= (str-index fmt (+ offset 1)) \u)
+          (cond
+            (nil? args) (error '{:err arity-error :desc "too few format arguments"})
+            :else       (format-v-impl (concat acc (unsigned->string (car args))) (+ offset 2) fmt (cdr args)))
+        :else
+          (error {:err 'fmt-error :desc "invalid format string" :char (str-index fmt (+ offset 1))}))
+    :else
+      (format-v-impl (push acc (index fmt offset)) (+ offset 1) fmt args)))
+
+(define (format-v fmt args)
+  (format-v-impl "" 0 fmt args))
+
+(define (format fmt ...args) (format-v fmt args))
+
+(define-macro (fn module definition ...body)
+  (let [fn-sym (gensym "lambda")]
+   `(let [,fn-sym (lambda ,(cdr definition) ,...body)]
+      (assign ,module (map-insert (get ,module) (quote ,(car definition)) ,fn-sym))
+      ,fn-sym)))
+
+(define-macro (export-impl acc offset mod-sym definitions)
+  (cond
+    (= offset (len definitions))
+      acc
+    (= (+ offset 1) (len definitions))
+      (error {:err 'arity-error :desc "export expects an even count of key-value pairs" :defs definitions})
+    :else
+      (let* [name   (index definitions offset)
+             value  (index definitions (+ offset 1))
+             n-sym  (gensym "value")
+             def   `(let [,n-sym ,value]
+                      (assign ,mod-sym (map-insert (get ,mod-sym) (quote ,name) ,n-sym))
+                      ,n-sym)
+             acc*   (push (push acc name) def)]
+        (export-impl acc* (+ offset 2) mod-sym definitions))))
+
+(define-macro (export definitions)
+  (let [mod-sym (gensym "module")]
+   `(let [,mod-sym (var {})]
+       (let* ,(export-impl [] 0 mod-sym definitions) (get ,mod-sym)))))
+
+(export [foo (lambda (x y) (+ x y))])

--- a/include/gtk-ml-internal.h
+++ b/include/gtk-ml-internal.h
@@ -41,6 +41,8 @@ struct GtkMl_Gc {
 };
 
 struct GtkMl_Context {
+    GtkMl_Builder *default_builder;
+    GtkMl_Program *program;
     GtkMl_SObj bindings;
 
     GtkMl_Gc *gc;
@@ -124,6 +126,7 @@ GTKML_PUBLIC gboolean gtk_ml_backtracef_debug(GtkMl_Context *ctx, FILE *stream, 
 // creates a new context on the heap, with an existing gc
 // must be deleted with `gtk_ml_del_context`
 GTKML_PUBLIC GtkMl_Context *gtk_ml_new_context_with_gc(GtkMl_Gc *gc) GTKML_MUST_USE;
+GTKML_PUBLIC GtkMl_Context *gtk_ml_new_context_with_gc_builder(GtkMl_Gc *gc, GtkMl_Builder *builder) GTKML_MUST_USE;
 GTKML_PUBLIC GtkMl_Gc *gtk_ml_new_gc() GTKML_MUST_USE;
 GTKML_PUBLIC GtkMl_Gc *gtk_ml_gc_copy(GtkMl_Gc *gc) GTKML_MUST_USE;
 GTKML_PUBLIC void gtk_ml_del_gc(GtkMl_Context *ctx, GtkMl_Gc *gc);
@@ -156,6 +159,7 @@ GTKML_PUBLIC GtkMl_SObj gtk_ml_parse_unquote(GtkMl_Context *ctx, GtkMl_SObj *err
 GTKML_PUBLIC GtkMl_SObj gtk_ml_parse_alternative(GtkMl_Context *ctx, GtkMl_SObj *err, GtkMl_Token **tokenv, size_t *tokenc) GTKML_MUST_USE;
 GTKML_PUBLIC GtkMl_SObj gtk_ml_parse_get(GtkMl_Context *ctx, GtkMl_SObj *err, GtkMl_Token **tokenv, size_t *tokenc) GTKML_MUST_USE;
 
+GTKML_PUBLIC gboolean gtk_ml_builder_load(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_SObj *err, GtkMl_SObj *stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) GTKML_MUST_USE;
 #ifdef GTKML_ENABLE_GTK
 GTKML_PUBLIC gboolean gtk_ml_builder_application(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_SObj *err, GtkMl_SObj *stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) GTKML_MUST_USE;
 GTKML_PUBLIC gboolean gtk_ml_builder_new_window(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_SObj *err, GtkMl_SObj *stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) GTKML_MUST_USE;
@@ -203,6 +207,14 @@ GTKML_PUBLIC gboolean gtk_ml_builder_index(GtkMl_Context *ctx, GtkMl_Builder *b,
 GTKML_PUBLIC gboolean gtk_ml_builder_push(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_SObj *err, GtkMl_SObj *stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) GTKML_MUST_USE;
 GTKML_PUBLIC gboolean gtk_ml_builder_pop(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_SObj *err, GtkMl_SObj *stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) GTKML_MUST_USE;
 GTKML_PUBLIC gboolean gtk_ml_builder_concat(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_SObj *err, GtkMl_SObj *stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) GTKML_MUST_USE;
+GTKML_PUBLIC gboolean gtk_ml_builder_map_get(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_SObj *err, GtkMl_SObj *stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) GTKML_MUST_USE;
+GTKML_PUBLIC gboolean gtk_ml_builder_map_insert(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_SObj *err, GtkMl_SObj *stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) GTKML_MUST_USE;
+GTKML_PUBLIC gboolean gtk_ml_builder_map_delete(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_SObj *err, GtkMl_SObj *stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) GTKML_MUST_USE;
+GTKML_PUBLIC gboolean gtk_ml_builder_map_concat(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_SObj *err, GtkMl_SObj *stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) GTKML_MUST_USE;
+GTKML_PUBLIC gboolean gtk_ml_builder_set_contains(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_SObj *err, GtkMl_SObj *stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) GTKML_MUST_USE;
+GTKML_PUBLIC gboolean gtk_ml_builder_set_insert(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_SObj *err, GtkMl_SObj *stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) GTKML_MUST_USE;
+GTKML_PUBLIC gboolean gtk_ml_builder_set_delete(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_SObj *err, GtkMl_SObj *stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) GTKML_MUST_USE;
+GTKML_PUBLIC gboolean gtk_ml_builder_set_concat(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_SObj *err, GtkMl_SObj *stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) GTKML_MUST_USE;
 GTKML_PUBLIC gboolean gtk_ml_builder_add(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_SObj *err, GtkMl_SObj *stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) GTKML_MUST_USE;
 GTKML_PUBLIC gboolean gtk_ml_builder_sub(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_SObj *err, GtkMl_SObj *stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) GTKML_MUST_USE;
 GTKML_PUBLIC gboolean gtk_ml_builder_mul(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_SObj *err, GtkMl_SObj *stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) GTKML_MUST_USE;

--- a/include/gtk-ml-internal.h
+++ b/include/gtk-ml-internal.h
@@ -158,6 +158,7 @@ GTKML_PUBLIC GtkMl_SObj gtk_ml_parse_quasiquote(GtkMl_Context *ctx, GtkMl_SObj *
 GTKML_PUBLIC GtkMl_SObj gtk_ml_parse_unquote(GtkMl_Context *ctx, GtkMl_SObj *err, GtkMl_Token **tokenv, size_t *tokenc) GTKML_MUST_USE;
 GTKML_PUBLIC GtkMl_SObj gtk_ml_parse_alternative(GtkMl_Context *ctx, GtkMl_SObj *err, GtkMl_Token **tokenv, size_t *tokenc) GTKML_MUST_USE;
 GTKML_PUBLIC GtkMl_SObj gtk_ml_parse_get(GtkMl_Context *ctx, GtkMl_SObj *err, GtkMl_Token **tokenv, size_t *tokenc) GTKML_MUST_USE;
+GTKML_PUBLIC GtkMl_SObj gtk_ml_parse_dot(GtkMl_Context *ctx, GtkMl_SObj *err, GtkMl_Token **tokenv, size_t *tokenc) GTKML_MUST_USE;
 
 GTKML_PUBLIC gboolean gtk_ml_builder_load(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_SObj *err, GtkMl_SObj *stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) GTKML_MUST_USE;
 #ifdef GTKML_ENABLE_GTK

--- a/include/gtk-ml-internal.h
+++ b/include/gtk-ml-internal.h
@@ -20,11 +20,11 @@ struct GtkMl_Gc {
     size_t stack_cap;
 
     GtkMl_SObj *local;
-    size_t local_len;
-    size_t local_cap;
-    size_t local_base;
+    int64_t local_len;
+    int64_t local_cap;
+    int64_t local_base;
 
-    uint64_t *base_stack;
+    int64_t *base_stack;
     size_t base_stack_ptr;
     size_t base_stack_cap;
 
@@ -65,11 +65,11 @@ struct GtkMl_Vm {
     size_t stack_cap;
 
     GtkMl_TaggedValue *local;
-    size_t local_len;
-    size_t local_cap;
-    size_t local_base;
+    int64_t local_len;
+    int64_t local_cap;
+    int64_t local_base;
 
-    uint64_t *base_stack;
+    int64_t *base_stack;
     size_t base_stack_ptr;
     size_t base_stack_cap;
 
@@ -136,11 +136,11 @@ GTKML_PUBLIC GtkMl_SObj gtk_ml_gc_pop(GtkMl_Gc *gc);
 GTKML_PUBLIC GtkMl_SObj gtk_ml_gc_peek(GtkMl_Context *gc);
 
 // early-builds the program's intrinsics
-GTKML_PUBLIC GtkMl_Program *gtk_ml_build_intr_apply(GtkMl_Context *ctx, GtkMl_SObj *err, GtkMl_Builder *b) GTKML_MUST_USE;
+GTKML_PUBLIC GtkMl_Program *gtk_ml_build_intr_apply(GtkMl_Context *ctx, GtkMl_SObj *err, GtkMl_Builder *b, GtkMl_Program **additional_programs, size_t n_programs) GTKML_MUST_USE;
 // builds the program's intrinsics
-GTKML_PUBLIC GtkMl_Program *gtk_ml_build_intrinsics(GtkMl_Context *ctx, GtkMl_SObj *err, GtkMl_Builder *b) GTKML_MUST_USE;
+GTKML_PUBLIC GtkMl_Program *gtk_ml_build_intrinsics(GtkMl_Context *ctx, GtkMl_SObj *err, GtkMl_Builder *b, GtkMl_Program **additional_programs, size_t n_programs) GTKML_MUST_USE;
 // builds the program's macros
-GTKML_PUBLIC GtkMl_Program *gtk_ml_build_macros(GtkMl_Context *ctx, GtkMl_SObj *err, GtkMl_Builder *b) GTKML_MUST_USE;
+GTKML_PUBLIC GtkMl_Program *gtk_ml_build_macros(GtkMl_Context *ctx, GtkMl_SObj *err, GtkMl_Builder *b, GtkMl_Program **additional_programs, size_t n_programs) GTKML_MUST_USE;
 
 GTKML_PUBLIC GtkMl_TaggedValue gtk_ml_to_sobj(GtkMl_Context *ctx, GtkMl_SObj *err, GtkMl_TaggedValue value);
 GTKML_PUBLIC GtkMl_TaggedValue gtk_ml_to_prim(GtkMl_Context *ctx, GtkMl_SObj *err, GtkMl_TaggedValue sobj);
@@ -233,7 +233,6 @@ GTKML_PUBLIC void gtk_ml_vm_push(GtkMl_Vm *vm, GtkMl_TaggedValue value);
 GTKML_PUBLIC GtkMl_TaggedValue gtk_ml_vm_pop(GtkMl_Vm *vm);
 
 GTKML_PUBLIC gboolean gtk_ml_i_nop(GtkMl_Vm *vm, GtkMl_SObj *err, uint64_t data) GTKML_MUST_USE;
-GTKML_PUBLIC gboolean gtk_ml_i_halt(GtkMl_Vm *vm, GtkMl_SObj *err, uint64_t data) GTKML_MUST_USE;
 GTKML_PUBLIC gboolean gtk_ml_i_signed_add(GtkMl_Vm *vm, GtkMl_SObj *err, uint64_t data) GTKML_MUST_USE;
 GTKML_PUBLIC gboolean gtk_ml_i_signed_subtract(GtkMl_Vm *vm, GtkMl_SObj *err, uint64_t data) GTKML_MUST_USE;
 GTKML_PUBLIC gboolean gtk_ml_i_signed_multiply(GtkMl_Vm *vm, GtkMl_SObj *err, uint64_t data) GTKML_MUST_USE;
@@ -308,7 +307,7 @@ GTKML_PUBLIC gboolean gtk_ml_compile_cond_expression(GtkMl_Context *ctx, GtkMl_B
 GTKML_PUBLIC gboolean gtk_ml_compile_quasi_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_SObj *err, GtkMl_SObj stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion, gboolean *unwrapped) GTKML_MUST_USE;
 GTKML_PUBLIC gboolean gtk_ml_compile_expression(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_SObj *err, GtkMl_SObj *stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) GTKML_MUST_USE;
 GTKML_PUBLIC gboolean gtk_ml_compile_body(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_SObj *err, GtkMl_SObj stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion) GTKML_MUST_USE;
-GTKML_PUBLIC gboolean gtk_ml_compile_program_internal(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_SObj *err, const char *linkage_name, GtkMl_SObj stmt, gboolean ret, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion, GtkMl_ProgramKind kind) GTKML_MUST_USE;
+GTKML_PUBLIC gboolean gtk_ml_compile_program_internal(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock **basic_block, GtkMl_SObj *err, const char *linkage_name, GtkMl_SObj stmt, gboolean allow_intr, gboolean allow_macro, gboolean allow_runtime, gboolean allow_macro_expansion, GtkMl_ProgramKind kind) GTKML_MUST_USE;
 
 // compile a lambda expression to bytecode
 GTKML_PUBLIC gboolean gtk_ml_compile_intrinsics(GtkMl_Builder *b, GtkMl_BasicBlock **start, GtkMl_SObj *err, GtkMl_SObj intrinsic) GTKML_MUST_USE;

--- a/include/gtk-ml.h
+++ b/include/gtk-ml.h
@@ -75,13 +75,14 @@ typedef int gboolean;
 #define GTKML_F_NONE 0x0
 #define GTKML_F_GENERIC (GTKML_F_EQUAL | GTKML_F_NEQUAL | GTKML_F_OVERFLOW | GTKML_F_CARRY)
 
+#define GTKML_CORE_LOAD 0x0
 #ifdef GTKML_ENABLE_GTK
-#define GTKML_CORE_APPLICATION 0x0
-#define GTKML_CORE_NEW_WINDOW 0x1
+#define GTKML_CORE_APPLICATION 0x1
+#define GTKML_CORE_NEW_WINDOW 0x2
 #endif /* GTKML_ENABLE_GTK */
-#define GTKML_CORE_ERROR 0x2
-#define GTKML_CORE_DBG 0x3
-#define GTKML_CORE_STRING_TO_SYMBOL 0x4
+#define GTKML_CORE_ERROR 0x3
+#define GTKML_CORE_DBG 0x4
+#define GTKML_CORE_STRING_TO_SYMBOL 0x5
 #define GTKML_CORE_COMPILE_EXPR 0x100
 #define GTKML_CORE_EMIT_BYTECODE 0x101
 #define GTKML_CORE_BIND_SYMBOL 0x102
@@ -848,11 +849,15 @@ GTKML_PUBLIC gboolean gtk_ml_build_map_insert(GtkMl_Context *ctx, GtkMl_Builder 
 // builds a push in the chosen basic_block
 GTKML_PUBLIC gboolean gtk_ml_build_map_delete(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_SObj *err) GTKML_MUST_USE;
 // builds a push in the chosen basic_block
+GTKML_PUBLIC gboolean gtk_ml_build_map_concat(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_SObj *err) GTKML_MUST_USE;
+// builds a push in the chosen basic_block
 GTKML_PUBLIC gboolean gtk_ml_build_set_contains(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_SObj *err) GTKML_MUST_USE;
 // builds a push in the chosen basic_block
 GTKML_PUBLIC gboolean gtk_ml_build_set_insert(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_SObj *err) GTKML_MUST_USE;
 // builds a push in the chosen basic_block
 GTKML_PUBLIC gboolean gtk_ml_build_set_delete(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_SObj *err) GTKML_MUST_USE;
+// builds a push in the chosen basic_block
+GTKML_PUBLIC gboolean gtk_ml_build_set_concat(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_SObj *err) GTKML_MUST_USE;
 // builds a call to C in the chosen basic_block
 GTKML_PUBLIC gboolean gtk_ml_build_call_core(GtkMl_Context *ctx, GtkMl_Builder *b, GtkMl_BasicBlock *basic_block, GtkMl_SObj *err, GtkMl_Data data) GTKML_MUST_USE;
 // builds a call instruction in the chosen basic_block

--- a/src/bytecode.c
+++ b/src/bytecode.c
@@ -1402,7 +1402,7 @@ gboolean gtk_ml_i_map_insert(GtkMl_Vm *vm, GtkMl_SObj *err, GtkMl_Data data) {
     gtk_ml_del_hash_trie(vm->ctx, &result->value.s_map.map, gtk_ml_delete_value);
 
     switch (container->kind) {
-    case GTKML_S_ARRAY:
+    case GTKML_S_MAP:
         gtk_ml_hash_trie_insert(&result->value.s_map.map, &container->value.s_map.map, key, value);
         gtk_ml_push(vm->ctx, gtk_ml_value_sobject(result));
         break;
@@ -1429,7 +1429,7 @@ gboolean gtk_ml_i_map_delete(GtkMl_Vm *vm, GtkMl_SObj *err, GtkMl_Data data) {
     gtk_ml_del_hash_trie(vm->ctx, &result->value.s_map.map, gtk_ml_delete_value);
 
     switch (container->kind) {
-    case GTKML_S_ARRAY:
+    case GTKML_S_MAP:
         gtk_ml_hash_trie_delete(&result->value.s_map.map, &container->value.s_map.map, key);
         gtk_ml_push(vm->ctx, gtk_ml_value_sobject(result));
         break;
@@ -1481,7 +1481,7 @@ gboolean gtk_ml_i_set_insert(GtkMl_Vm *vm, GtkMl_SObj *err, GtkMl_Data data) {
     gtk_ml_del_hash_set(vm->ctx, &result->value.s_set.set, gtk_ml_delete_value);
 
     switch (container->kind) {
-    case GTKML_S_ARRAY:
+    case GTKML_S_SET:
         gtk_ml_hash_set_insert(&result->value.s_set.set, &container->value.s_set.set, key);
         gtk_ml_push(vm->ctx, gtk_ml_value_sobject(result));
         break;
@@ -1508,7 +1508,7 @@ gboolean gtk_ml_i_set_delete(GtkMl_Vm *vm, GtkMl_SObj *err, GtkMl_Data data) {
     gtk_ml_del_hash_set(vm->ctx, &result->value.s_set.set, gtk_ml_delete_value);
 
     switch (container->kind) {
-    case GTKML_S_ARRAY:
+    case GTKML_S_SET:
         gtk_ml_hash_set_delete(&result->value.s_set.set, &container->value.s_set.set, key);
         gtk_ml_push(vm->ctx, gtk_ml_value_sobject(result));
         break;

--- a/src/bytecode.c
+++ b/src/bytecode.c
@@ -83,14 +83,6 @@ gboolean gtk_ml_i_nop(GtkMl_Vm *vm, GtkMl_SObj *err, GtkMl_Data data) {
     return 1;
 }
 
-gboolean gtk_ml_i_halt(GtkMl_Vm *vm, GtkMl_SObj *err, GtkMl_Data data) {
-    (void) err;
-    (void) data;
-    vm->flags |= GTKML_F_HALT;
-    PC_INCREMENT;
-    return 1;
-}
-
 GTKML_PRIVATE void set_flags(GtkMl_Vm *vm, GtkMl_TaggedValue result) {
     // TODO(walterpi): overflow, carry
     if (gtk_ml_is_primitive(result)) {
@@ -877,6 +869,7 @@ gboolean gtk_ml_i_define(GtkMl_Vm *vm, GtkMl_SObj *err, GtkMl_Data data) {
     GtkMl_SObj key = gtk_ml_to_sobj(vm->ctx, err, gtk_ml_pop(vm->ctx)).value.sobj;
     GtkMl_TaggedValue value = gtk_ml_pop(vm->ctx);
     gtk_ml_bind(vm->ctx, key, value);
+    gtk_ml_push(vm->ctx, gtk_ml_value_nil());
     PC_INCREMENT;
     return 1;
 }
@@ -1017,7 +1010,7 @@ gboolean gtk_ml_i_get_imm(GtkMl_Vm *vm, GtkMl_SObj *err, GtkMl_Data data) {
 gboolean gtk_ml_i_local_imm(GtkMl_Vm *vm, GtkMl_SObj *err, GtkMl_Data data) {
     (void) err;
     (void) data;
-    size_t offset = gtk_ml_get_data(vm->program, data).value.u64;
+    int64_t offset = gtk_ml_get_data(vm->program, data).value.s64;
     GtkMl_TaggedValue value = gtk_ml_get_local(vm->ctx, offset);
     if (gtk_ml_has_value(value)) {
         gtk_ml_push(vm->ctx, value);
@@ -1560,6 +1553,9 @@ gboolean gtk_ml_i_leave_ret(GtkMl_Vm *vm, GtkMl_SObj *err, GtkMl_Data data) {
     (void) data;
 
     if (vm->flags & GTKML_F_TOPCALL) {
+        LEAVE(vm, vm->ctx->gc);
+        LEAVE(vm, vm->ctx->gc);
+
         vm->flags |= GTKML_F_HALT;
         PC_INCREMENT;
     } else {

--- a/src/gtk-ml.c
+++ b/src/gtk-ml.c
@@ -16,7 +16,6 @@
 
 GTKML_PRIVATE const char *S_OPCODES[] = {
     [GTKML_I_NOP] = GTKML_SI_NOP,
-    [GTKML_I_HALT] = GTKML_SI_HALT,
     [GTKML_I_ADD] = GTKML_SI_ADD,
     [GTKML_I_SUBTRACT] = GTKML_SI_SUBTRACT,
     [GTKML_I_SIGNED_MULTIPLY] = GTKML_SI_SIGNED_MULTIPLY,
@@ -810,7 +809,7 @@ GTKML_PRIVATE void mark(GtkMl_Context *ctx) {
     for (size_t sp = 0; sp < ctx->gc->stack_len; sp++) {
         mark_sobject(ctx->gc->stack[sp]);
     }
-    for (size_t sp = 0; sp < ctx->gc->local_len; sp++) {
+    for (int64_t sp = 0; sp < ctx->gc->local_len; sp++) {
         mark_sobject(ctx->gc->local[sp]);
     }
     if (ctx->gc->static_stack) {

--- a/src/gtk-ml.c
+++ b/src/gtk-ml.c
@@ -172,6 +172,7 @@ GtkMl_Context *gtk_ml_new_context_with_gc_builder(GtkMl_Gc *gc, GtkMl_Builder *b
     gtk_ml_add_reader(ctx, GTKML_TOK_COMMA, gtk_ml_parse_unquote);
     gtk_ml_add_reader(ctx, GTKML_TOK_POUND, gtk_ml_parse_alternative);
     gtk_ml_add_reader(ctx, GTKML_TOK_AT, gtk_ml_parse_get);
+    gtk_ml_add_reader(ctx, GTKML_TOK_DOT, gtk_ml_parse_dot);
 
     return ctx;
 }

--- a/src/gtkml-dbg.c
+++ b/src/gtkml-dbg.c
@@ -277,14 +277,16 @@ int main(int argc, const char **argv, char *const *envp) {
         return 0;
     }
 
+    GtkMl_SObj s_flags = gtk_ml_new_map(ctx, NULL, NULL);
+    s_flags->value.s_map.map = flags;
+    gtk_ml_push(ctx, gtk_ml_value_sobject(s_flags));
+    GtkMl_SObj s_opts = gtk_ml_new_map(ctx, NULL, NULL);
+    s_opts->value.s_map.map = opts;
+    gtk_ml_push(ctx, gtk_ml_value_sobject(s_opts));
+
     GtkMl_SObj verbose_kw = gtk_ml_new_keyword(ctx, NULL, 0, PARAMS['v'].long_opt, strlen(PARAMS['v'].long_opt));
     GtkMl_TaggedValue verbose_opt = gtk_ml_hash_trie_get(&flags, gtk_ml_value_sobject(verbose_kw));
     if (verbose_opt.value.sobj->kind == GTKML_S_TRUE) {
-        GtkMl_SObj s_flags = gtk_ml_new_map(ctx, NULL, NULL);
-        s_flags->value.s_map.map = flags;
-        GtkMl_SObj s_opts = gtk_ml_new_map(ctx, NULL, NULL);
-        s_opts->value.s_map.map = opts;
-
         fprintf(stderr, "running with flags: ");
         (void) gtk_ml_dumpf(ctx, stderr, &err, s_flags);
         fprintf(stderr, "\nrunning with options: ");
@@ -364,6 +366,10 @@ int main(int argc, const char **argv, char *const *envp) {
 
         gtk_ml_set_debug(ctx, pid, (GtkMl_Context *) regs.rax);
 
+        GtkMl_Builder *builder = gtk_ml_new_builder(ctx);
+        GtkMl_Program *previous_program = NULL;
+        size_t n_previous = 0;
+
         linenoiseInstallWindowChangeHandler();
 
         //linenoiseSetCompletionCallback(completionHook);
@@ -420,8 +426,6 @@ int main(int argc, const char **argv, char *const *envp) {
                     continue;
                 }
 
-                GtkMl_Builder *builder = gtk_ml_new_builder(ctx);
-
                 if (!gtk_ml_compile_program(ctx, builder, &err, lambda)) {
                     free(src);
                     src = NULL;
@@ -431,7 +435,7 @@ int main(int argc, const char **argv, char *const *envp) {
                     continue;
                 }
 
-                GtkMl_Program *program = gtk_ml_build(ctx, &err, builder);
+                GtkMl_Program *program = gtk_ml_build(ctx, &err, builder, &previous_program, n_previous);
                 if (!program) {
                     free(src);
                     src = NULL;
@@ -440,6 +444,9 @@ int main(int argc, const char **argv, char *const *envp) {
                     fprintf(stderr, "\n");
                     continue;
                 }
+
+                previous_program = program;
+                n_previous = 1;
 
                 gtk_ml_load_program(ctx, program);
 

--- a/src/gtkml-dbg.c
+++ b/src/gtkml-dbg.c
@@ -10,7 +10,9 @@
 #include <sys/user.h>
 #include <gtk/gtk.h>
 #include <linenoise.h>
+#define GTKML_INCLUDE_INTERNAL
 #include "gtk-ml.h"
+#include "gtk-ml-internal.h"
 
 #define GTKML_DBG_VERSION "gtkml1dbg ver. 0.0.0"
 
@@ -366,7 +368,7 @@ int main(int argc, const char **argv, char *const *envp) {
 
         gtk_ml_set_debug(ctx, pid, (GtkMl_Context *) regs.rax);
 
-        GtkMl_Builder *builder = gtk_ml_new_builder(ctx);
+        GtkMl_Builder *builder = ctx->default_builder;
         GtkMl_Program *previous_program = NULL;
         size_t n_previous = 0;
 

--- a/src/gtkml-web.c
+++ b/src/gtkml-web.c
@@ -1,7 +1,9 @@
 #include <stdlib.h>
 #include <string.h>
 #include <emscripten.h>
+#define GTKML_INCLUDE_INTERNAL
 #include "gtk-ml.h"
+#include "gtk-ml-internal.h"
 
 #define GTKMLWEB_VERSION "gtkml-web ver. 0.0.0"
 
@@ -78,6 +80,6 @@ int main() {
     size_t *n_previous = malloc(sizeof(size_t));
     *n_previous = 0;
     GtkMl_Context *ctx = gtk_ml_new_context();
-    EM_ASM({ gtk_ml_js_init($0, $1, $2, $3) }, ctx, gtk_ml_new_builder(ctx), previous_program, n_previous);
+    EM_ASM({ gtk_ml_js_init($0, $1, $2, $3) }, ctx, ctx->default_builder, previous_program, n_previous);
     return 0;
 }

--- a/src/gtkml-web.js
+++ b/src/gtkml-web.js
@@ -3,7 +3,11 @@ gtk_ml_web_deinit = undefined
 gtk_ml_web_version = undefined
 gtk_ml_web_eval = undefined
 
-gtk_ml_ctx = undefined
+gtk_web_ctx = undefined
+gtk_web_builder = undefined
+gtk_web_prev = undefined
+gtk_web_nprev = undefined
+gtk_web_history = []
 
 function gtk_ml_js_read_stdin() {
     let result = document.getElementById('gtkml-stdin').value;
@@ -11,22 +15,26 @@ function gtk_ml_js_read_stdin() {
     return result;
 }
 
-function gtk_ml_js_init(_ctx) {
-    document.getElementById('gtkml-stdout').value = '';
-    document.getElementById('gtkml-stderr').value = '';
+function gtk_ml_js_init(_ctx, _builder, _prev, _nprev) {
     gtk_ml_web_init = Module.cwrap('gtk_ml_web_init', 'number', []); // number acts as GtkMl_Context *
-    gtk_ml_web_deinit = Module.cwrap('gtk_ml_web_deinit', null, ['number']); // number acts as GtkMl_Context *
+    gtk_ml_web_deinit = Module.cwrap('gtk_ml_web_deinit', null, ['number', 'number', 'number', 'number']); // numbers act as GtkMl_Context *, GtkMl_Program ** and size_t *
     gtk_ml_web_version = Module.cwrap('gtk_ml_web_version', 'string', []);
-    gtk_ml_web_eval = Module.cwrap('gtk_ml_web_eval', 'string', ['number', 'string']); // number acts as GtkMl_Context *
+    gtk_ml_web_eval = Module.cwrap('gtk_ml_web_eval', 'string', ['number', 'string', 'number', 'number', 'number']); // numbers act as GtkMl_Context *, GtkMl_Program ** and size_t *
+    document.getElementById('gtkml-stdout').value = gtk_ml_web_version() + '\n';
+    document.getElementById('gtkml-stderr').value = '';
 
-    gtk_ml_ctx = _ctx;
+    gtk_web_ctx = _ctx;
+    gtk_web_builder = _builder;
+    gtk_web_prev = _prev;
+    gtk_web_nprev = _nprev;
 }
 
 function gtk_ml_js_run() {
-    if (typeof(gtk_ml_ctx) == 'undefined') {
+    if (typeof(gtk_web_ctx) == 'undefined') {
         document.getElementById('gtkml-output').value = "Please wait until the web runtime has been initialized.";
         return;
     }
-    let output = gtk_ml_web_eval(gtk_ml_ctx, document.getElementById('gtkml-input').value);
+    gtk_web_history.push(document.getElementById('gtkml-input').value);
+    let output = gtk_ml_web_eval(gtk_web_ctx, gtk_web_history[gtk_web_history.length - 1], gtk_web_builder, gtk_web_prev, gtk_web_nprev);
     document.getElementById('gtkml-output').value = output;
 }

--- a/src/gtkmli.c
+++ b/src/gtkmli.c
@@ -2,7 +2,9 @@
 #include <string.h>
 #include <errno.h>
 #include <gtk/gtk.h>
+#define GTKML_INCLUDE_INTERNAL
 #include "gtk-ml.h"
+#include "gtk-ml-internal.h"
 
 #define GTKMLI_VERSION "gtkmli ver. 0.0.0"
 
@@ -92,7 +94,7 @@ void print_version(const char *arg0) {
 int main(int argc, const char **argv) {
     GtkMl_SObj err = NULL;
 
-    GtkMl_Context *ctx = gtk_ml_new_debugger(-1);
+    GtkMl_Context *ctx = gtk_ml_new_context();
 
     const char *rest = NULL;
 
@@ -242,7 +244,7 @@ int main(int argc, const char **argv) {
         fprintf(stderr, "\n");
     }
 
-    GtkMl_Builder *builder = gtk_ml_new_builder(ctx);
+    GtkMl_Builder *builder = ctx->default_builder;
     GtkMl_Program *previous_program = NULL;
     size_t n_previous = 0;
 

--- a/src/parse.c
+++ b/src/parse.c
@@ -223,6 +223,36 @@ GtkMl_SObj gtk_ml_parse_get(GtkMl_Context *ctx, GtkMl_SObj *err, GtkMl_Token **t
     return gtk_ml_new_list(ctx, &span, get, gtk_ml_new_list(ctx, &span, expr, gtk_ml_new_nil(ctx, &span)));
 }
 
+GtkMl_SObj gtk_ml_parse_dot(GtkMl_Context *ctx, GtkMl_SObj *err, GtkMl_Token **tokenv, size_t *tokenc) {
+    if ((*tokenv)[0].kind != GTKML_TOK_DOT) {
+        *err = gtk_ml_error(ctx, "token-error", GTKML_ERR_TOKEN_ERROR, (*tokenv)[*tokenc].span.ptr != NULL, (*tokenv)[*tokenc].span.line, (*tokenv)[*tokenc].span.col, 0);
+        return NULL;
+    }
+
+    GtkMl_Span span = (*tokenv)[0].span;
+
+    GtkMl_SObj get = gtk_ml_new_symbol(ctx, &span, 0, "map-get", strlen("map-get"));
+
+    ++*tokenv;
+    --*tokenc;
+
+    GtkMl_SObj key = gtk_ml_parse(ctx, err, tokenv, tokenc);
+    if (!key) {
+        return NULL;
+    }
+
+    key = gtk_ml_new_quasiquote(ctx, &key->span, key);
+
+    GtkMl_SObj map = gtk_ml_parse(ctx, err, tokenv, tokenc);
+    if (!map) {
+        return NULL;
+    }
+
+    span_add(&span, &span, &map->span);
+
+    return gtk_ml_new_list(ctx, &span, get, gtk_ml_new_list(ctx, &span, map, gtk_ml_new_list(ctx, &span, key, gtk_ml_new_nil(ctx, &span))));
+}
+
 GtkMl_SObj gtk_ml_parse_list_rest(GtkMl_Context *ctx, GtkMl_SObj *err, GtkMl_Token **tokenv, size_t *tokenc) {
     if (*tokenc == 0) {
         *err = gtk_ml_error(ctx, "eof-error", GTKML_ERR_EOF_ERROR, (*tokenv)[*tokenc].span.ptr != NULL, (*tokenv)[*tokenc].span.line, (*tokenv)[*tokenc].span.col, 0);

--- a/src/value.c
+++ b/src/value.c
@@ -152,17 +152,33 @@ GtkMl_SObj gtk_ml_new_string(GtkMl_Context *ctx, GtkMl_Span *span, const char *p
 
 GtkMl_SObj gtk_ml_new_symbol(GtkMl_Context *ctx, GtkMl_Span *span, gboolean owned, const char *ptr, size_t len) {
     GtkMl_SObj s = gtk_ml_new_sobject(ctx, span, GTKML_S_SYMBOL);
-    s->value.s_symbol.owned = owned;
-    s->value.s_symbol.ptr = ptr;
-    s->value.s_symbol.len = len;
+    s->value.s_symbol.owned = 1;
+    if (owned) {
+        s->value.s_symbol.ptr = ptr;
+        s->value.s_symbol.len = len;
+    } else {
+        char *sym = malloc(len + 1);
+        memcpy(sym, ptr, len);
+        sym[len] = 0;
+        s->value.s_symbol.ptr = sym;
+        s->value.s_symbol.len = len;
+    }
     return s;
 }
 
 GtkMl_SObj gtk_ml_new_keyword(GtkMl_Context *ctx, GtkMl_Span *span, gboolean owned, const char *ptr, size_t len) {
     GtkMl_SObj s = gtk_ml_new_sobject(ctx, span, GTKML_S_KEYWORD);
-    s->value.s_keyword.owned = owned;
-    s->value.s_keyword.ptr = ptr;
-    s->value.s_keyword.len = len;
+    s->value.s_keyword.owned = 1;
+    if (owned) {
+        s->value.s_keyword.ptr = ptr;
+        s->value.s_keyword.len = len;
+    } else {
+        char *sym = malloc(len + 1);
+        memcpy(sym, ptr, len);
+        sym[len] = 0;
+        s->value.s_keyword.ptr = sym;
+        s->value.s_keyword.len = len;
+    }
     return s;
 }
 

--- a/src/vm.c
+++ b/src/vm.c
@@ -14,7 +14,6 @@
 
 GTKML_PRIVATE gboolean (*OPCODES[])(GtkMl_Vm *, GtkMl_SObj *, GtkMl_Data) = {
     [GTKML_I_NOP] = gtk_ml_i_nop,
-    [GTKML_I_HALT] = gtk_ml_i_halt,
     [GTKML_I_ADD] = gtk_ml_i_signed_add,
     [GTKML_I_SUBTRACT] = gtk_ml_i_signed_subtract,
     [GTKML_I_SIGNED_MULTIPLY] = gtk_ml_i_signed_multiply,
@@ -400,9 +399,7 @@ GtkMl_TaggedValue vm_core_emit_bytecode(GtkMl_Context *ctx, GtkMl_SObj *err, Gtk
     }
 
     gtk_ml_builder_set_cond(arg_b, arg_cond);
-    if (strlen(GTKML_SI_HALT) == len && strncmp(ptr, GTKML_SI_HALT, len) == 0) {
-        return gtk_ml_build_halt(arg_ctx, arg_b, arg_basic_block, err)? gtk_ml_value_true() : gtk_ml_value_none();
-    } else if (strlen(GTKML_SI_PUSH_IMM) == len && strncmp(ptr, GTKML_SI_PUSH_IMM, len) == 0) {
+    if (strlen(GTKML_SI_PUSH_IMM) == len && strncmp(ptr, GTKML_SI_PUSH_IMM, len) == 0) {
         if (!gtk_ml_has_value(data)) {
             *err = gtk_ml_error(ctx, "arity-error", GTKML_ERR_ARITY_ERROR, 0, 0, 0, 0);
             return gtk_ml_value_none();

--- a/test/hello.c
+++ b/test/hello.c
@@ -29,7 +29,7 @@ int main() {
         return 1;
     }
 
-    GtkMl_Program *linked = gtk_ml_build(ctx, &err, builder);
+    GtkMl_Program *linked = gtk_ml_build(ctx, &err, builder, NULL, 0);
     if (!linked) {
         free(src);
         (void) gtk_ml_dumpf(ctx, stderr, NULL, err);

--- a/test/match.c
+++ b/test/match.c
@@ -29,7 +29,7 @@ int main() {
         return 1;
     }
 
-    GtkMl_Program *linked = gtk_ml_build(ctx, &err, builder);
+    GtkMl_Program *linked = gtk_ml_build(ctx, &err, builder, NULL, 0);
     if (!linked) {
         free(src);
         (void) gtk_ml_dumpf(ctx, stderr, NULL, err);


### PR DESCRIPTION
This pr implements modules in the form of:

1. Linker improvements.
2. The `load` special form, which loads and immediately executes a file from a string at runtime.
3. The dot syntax.

Also, a new example includes an `export` macro, which makes it easier to export local functions while retaining `let*` semantics.

Here's a minimal example.

```clojure
;; in module.gtkml
(export [+1   (lambda (n) (+ n 1))
         *x+1 (lambda (a x) (+1 (* a x)))])
;; the export expression expands to something like this:
(let [module (var {})]
  (let* [+1   (let [value (lambda (n) (+ n 1)]
                (assign module (map-insert @module '+1 value))
                value)
         *x+1 (let [value (lambda (a x) (+1 (* a x)))]
                (assign module (map-insert @module '*x+1 value))
                value)]
    @module))

;; in main.gtkml
(let [mod (load "module.gtkml")]
  (dbg (.+1 mod 2)) ; .key map expands to (map-get map key)
  (dbg (.*x+1 mod 3 4)))
```